### PR TITLE
Fixes incorrect spacing in Setup and Files - step 4 of Certbot tab

### DIFF
--- a/public/partials/commands-do.html
+++ b/public/partials/commands-do.html
@@ -77,7 +77,9 @@
 	</li>
 	<li>
 		Uncomment SSL related directives in configuration:<br>
-		<code><span class="hljs-section">sed</span> <span class="hljs-attribute">-i -r</span> 's/#?;#//g' <span ng-if="isUnified()">{{ data.directory_nginx }}nginx.conf</span><span ng-if="isModularized()"><span ng-repeat="(_site, _domain) in getDomains() track by $index" ng-if="isCertLetsEncrypt(_site)">{{ data.directory_nginx }}sites-{{ isSymlink() ? 'available' : 'enabled' }}/{{ _domain }}.conf</span></span></code>
+		<code><span class="hljs-section">sed</span> <span class="hljs-attribute">-i -r</span> 's/#?;#//g'<span ng-if="isUnified()"><!--
+		--> {{ data.directory_nginx }}nginx.conf</span><span ng-if="isModularized()"><span ng-repeat="(_site, _domain) in getDomains() track by $index" ng-if="isCertLetsEncrypt(_site)"><!--
+		--> {{ data.directory_nginx }}sites-{{ isSymlink() ? 'available' : 'enabled' }}/{{ _domain }}.conf</span></span></code>
 	</li>
 	<li>
 		Reload NGINX:<br>


### PR DESCRIPTION
the list of multi site domains gets incorrectly joined together, this re-introduces the white space between each _/etc/..._ 

This issue isn't present on **master**, but does effect **do** and is present on digitalocean's online tool.

The magic happens with the <!-- --> multi line comments and spaces. (this is now consistent with section 1)