### PR TITLE
PHP-FPM Option w/o version

### DIFF
--- a/src/nginxconfig/i18n/en/templates/global_sections/php.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/php.js
@@ -38,5 +38,6 @@ export default {
     php72Socket: '7.2 socket',
     php73Socket: '7.3 socket',
     php74Socket: '7.4 socket',
+    phpSocket: 'PHP socket',
     disabled: 'Disabled',
 };

--- a/src/nginxconfig/templates/global_sections/php.vue
+++ b/src/nginxconfig/templates/global_sections/php.vue
@@ -95,11 +95,12 @@ THE SOFTWARE.
         '/var/run/php/php7.0-fpm.sock': `${i18n.templates.globalSections.php.php70Socket}: /var/run/php/php7.0-fpm.sock`,
         '/var/run/php/php7.3-fpm.sock': `${i18n.templates.globalSections.php.php73Socket}: /var/run/php/php7.3-fpm.sock`,
         '/var/run/php/php7.4-fpm.sock': `${i18n.templates.globalSections.php.php74Socket}: /var/run/php/php7.4-fpm.sock`,
+        '/var/run/php/php-fpm.sock': `${i18n.templates.globalSections.php.phpSocket}: /var/run/php/php-fpm.sock`,
     };
 
     const defaults = {
         phpServer: {
-            default: '/var/run/php/php7.2-fpm.sock',
+            default: '/var/run/php/php-fpm.sock',
             options: serverOptions,
             enabled: true,
         },


### PR DESCRIPTION
Digital Ocean Droplets have '/var/run/php/php-fpm.sock' managed by packet manager and linked to installed ver.
It better be this option as default just proposal.
