### PR TITLE
Only include pid when set

### DIFF
--- a/src/nginxconfig/generators/conf/nginx.conf.js
+++ b/src/nginxconfig/generators/conf/nginx.conf.js
@@ -38,8 +38,7 @@ export default (domains, global) => {
 
     // Basic nginx conf
     config.user = global.nginx.user.computed;
-    // Does not set pid if it is not set
-    if(global.nginx.pid.computed)
+    if (global.nginx.pid.computed)
         config.pid = global.nginx.pid.computed;
     config.worker_processes = global.nginx.workerProcesses.computed;
     config.worker_rlimit_nofile = 65535;

--- a/src/nginxconfig/generators/conf/nginx.conf.js
+++ b/src/nginxconfig/generators/conf/nginx.conf.js
@@ -38,7 +38,9 @@ export default (domains, global) => {
 
     // Basic nginx conf
     config.user = global.nginx.user.computed;
-    config.pid = global.nginx.pid.computed;
+    // Does not set pid if it is not set
+    if(global.nginx.pid.computed)
+        config.pid = global.nginx.pid.computed;
     config.worker_processes = global.nginx.workerProcesses.computed;
     config.worker_rlimit_nofile = 65535;
     config.events = {


### PR DESCRIPTION
## Type of Change
<!-- What part of the source are you modifying? Remove the irrelevant options. -->

- **Build Scripts:** nginx generator

## What issue does this relate to?
implements #168 

### What should this PR do?
It removes the pid property whenever there is no pid set.

### What are the acceptance criteria?
- that it is working as expected

before: 
![image](https://user-images.githubusercontent.com/20565303/94990911-b88a7800-057f-11eb-9abf-9192857a1db0.png)
after: 
![image](https://user-images.githubusercontent.com/20565303/94990920-c6d89400-057f-11eb-96ff-580e60c6a641.png)
