### PR TITLE
Syntax Highlighting for Docker and Yaml

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
     'plugin:vue/recommended',
   ],
   parserOptions: {
+    parser: "babel-eslint",
     ecmaVersion: 2018,
     sourceType: 'module',
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2458,6 +2458,20 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
     },
+    "babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      }
+    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@vue/cli-service": "^4.5.4",
+    "babel-eslint": "^10.1.0",
     "copyfiles": "^2.3.0",
     "duplicate-package-checker-webpack-plugin": "^3.0.0",
     "eslint": "^7.8.1",

--- a/src/nginxconfig/templates/app.vue
+++ b/src/nginxconfig/templates/app.vue
@@ -80,12 +80,15 @@ THE SOFTWARE.
                 <div :class="`column ${splitColumn ? 'is-half' : 'is-full'} is-full-touch`">
                     <h2>{{ i18n.templates.app.configFiles }}</h2>
                     <div ref="files" class="columns is-multiline files">
-                        <NginxPrism v-for="confContents in confFilesOutput"
-                                    :key="confContents[2]"
-                                    :name="confContents[0]"
-                                    :conf="confContents[1]"
-                                    :half="Object.keys(confFilesOutput).length > 1 && !splitColumn"
-                        ></NginxPrism>
+                        <template v-for="confContents in confFilesOutput">
+                            <component
+                                :is="getPrismComponent(confContents[0])"
+                                :key="confContents[2]"
+                                :name="confContents[0]"
+                                :conf="confContents[1]"
+                                :half="Object.keys(confFilesOutput).length > 1 && !splitColumn"
+                            ></component>
+                        </template>
                     </div>
                 </div>
             </div>
@@ -113,8 +116,9 @@ THE SOFTWARE.
     import Domain from './domain';
     import Global from './global';
     import Setup from './setup';
-    import NginxPrism from './prism/nginx';
     import Footer from './footer';
+
+    import NginxPrism from './prism/nginx';
 
     export default {
         name: 'App',
@@ -125,6 +129,8 @@ THE SOFTWARE.
             Global,
             Setup,
             NginxPrism,
+            'YamlPrism': () => import('./prism/yaml'),
+            'DockerPrism': () => import('./prism/docker'),
         },
         data() {
             return {
@@ -263,6 +269,17 @@ THE SOFTWARE.
             },
             splitColumnEvent(nonInteraction = false) {
                 analytics('toggle_split_column', 'Button', undefined, Number(this.$data.splitColumn), nonInteraction);
+            },
+            getPrismComponent(confName)
+            {
+                switch (confName) {
+                case '/etc/nginx/Dockerfile':
+                    return 'DockerPrism';
+                case '/etc/nginx/docker-compose.yaml':
+                    return 'YamlPrism';
+                default:
+                    return 'NginxPrism';
+                }
             },
         },
     };

--- a/src/nginxconfig/templates/prism/docker.vue
+++ b/src/nginxconfig/templates/prism/docker.vue
@@ -1,4 +1,4 @@
-/*
+<!--
 Copyright 2020 DigitalOcean
 
 This code is licensed under the MIT License.
@@ -22,30 +22,29 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-*/
+-->
 
-const path = require('path');
-const { LimitChunkCountPlugin } = require('webpack').optimize;
-const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
-const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin');
+<template>
+    <div :class="`column ${half ? 'is-half' : 'is-full'} is-full-mobile is-full-tablet`">
+        <h3 v-html="name"></h3>
+        <pre><code class="language-docker" v-html="conf"></code></pre>
+    </div>
+</template>
 
-module.exports = {
-    publicPath: './',
-    outputDir: 'dist',
-    filenameHashing: false, // Don't hash the output, so we can embed on the DigitalOcean Community
-    productionSourceMap: false,
-    configureWebpack: {
-        node: false, // Disable Node.js polyfills (Buffer etc.) -- This will be default in Webpack 5
-        plugins: [
-            process.argv.includes('--analyze') && new BundleAnalyzerPlugin(),
-            process.argv.includes('--analyze') && new DuplicatePackageCheckerPlugin(),
-        ].filter(x => !!x),
-    },
-    chainWebpack: config => {
-        // Use a custom HTML template
-        config.plugin('html').tap(options => {
-            options[0].template = path.join(__dirname, 'build', 'index.html');
-            return options;
-        });
-    },
-};
+<script>
+    import Prism from 'prismjs';
+    import 'prismjs/components/prism-docker';
+
+    export default {
+        name: 'DockerPrism',
+        props: {
+            name: String,
+            conf: String,
+            half: Boolean,
+        },
+        mounted() {
+            console.info(`Highlighting ${this.$props.name}...`);
+            Prism.highlightAllUnder(this.$el);
+        },
+    };
+</script>

--- a/src/nginxconfig/templates/prism/yaml.vue
+++ b/src/nginxconfig/templates/prism/yaml.vue
@@ -1,4 +1,4 @@
-/*
+<!--
 Copyright 2020 DigitalOcean
 
 This code is licensed under the MIT License.
@@ -22,30 +22,29 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-*/
+-->
 
-const path = require('path');
-const { LimitChunkCountPlugin } = require('webpack').optimize;
-const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
-const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin');
+<template>
+    <div :class="`column ${half ? 'is-half' : 'is-full'} is-full-mobile is-full-tablet`">
+        <h3 v-html="name"></h3>
+        <pre><code class="language-yaml" v-html="conf"></code></pre>
+    </div>
+</template>
 
-module.exports = {
-    publicPath: './',
-    outputDir: 'dist',
-    filenameHashing: false, // Don't hash the output, so we can embed on the DigitalOcean Community
-    productionSourceMap: false,
-    configureWebpack: {
-        node: false, // Disable Node.js polyfills (Buffer etc.) -- This will be default in Webpack 5
-        plugins: [
-            process.argv.includes('--analyze') && new BundleAnalyzerPlugin(),
-            process.argv.includes('--analyze') && new DuplicatePackageCheckerPlugin(),
-        ].filter(x => !!x),
-    },
-    chainWebpack: config => {
-        // Use a custom HTML template
-        config.plugin('html').tap(options => {
-            options[0].template = path.join(__dirname, 'build', 'index.html');
-            return options;
-        });
-    },
-};
+<script>
+    import Prism from 'prismjs';
+    import 'prismjs/components/prism-yaml';
+
+    export default {
+        name: 'YamlPrism',
+        props: {
+            name: String,
+            conf: String,
+            half: Boolean,
+        },
+        mounted() {
+            console.info(`Highlighting ${this.$props.name}...`);
+            Prism.highlightAllUnder(this.$el);
+        },
+    };
+</script>

--- a/vue.config.js
+++ b/vue.config.js
@@ -25,7 +25,6 @@ THE SOFTWARE.
 */
 
 const path = require('path');
-const { LimitChunkCountPlugin } = require('webpack').optimize;
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin');
 


### PR DESCRIPTION
## Type of Change
Implements dynamic components for Docker and Yaml Prism syntax highlighting.

I've also changed the limit of chunks allowed, this was necessary to allow the lazyloading of the Docker and Yaml Prism plugin and components. 

There was a note on the chunk limit that it was necessary for easy embedding. If this chunk limit gets implemented the PR still works - the components just won't lazyloaded.

Currently ESlint also errors due to the dynamic import. Importing and using `parser: "babel-eslint",` in `parserOptions` fixes this. Let me know if you would like another commit with this change. 

## What issue does this relate to?
Fixes #176 

### What should this PR do?
Implements Docker and Yaml Prism components for docker-composer and Dockerfile.
It also allows new prism components to be created an implemented.

### What are the acceptance criteria?
Check if removing the chunk limit is OK for embedding. 
Check ESlint issue
