### PR TITLE
Fix HTTP to HTTPS redirects for letsencrypt and subdomains

### DIFF
--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -113,7 +113,7 @@ const httpRedirectConfig = (domain, global, domainName, redirectDomain) => {
     }
 
     return config;
-}
+};
 
 export default (domain, domains, global) => {
     // Use kv so we can use the same key multiple times

--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -85,6 +85,37 @@ const listenConfig = domain => {
     return httpListen(domain);
 };
 
+
+function httpRedirectConfig(domain, global, domainName, redirectDomain)
+{
+    // Build the server config on its own before adding it to the parent config
+    const config = [];
+
+    config.push(...httpListen(domain));
+    config.push(['server_name', domainName]);
+
+    if (domain.https.certType.computed === 'letsEncrypt') {
+        // Let's encrypt
+
+        if (global.tools.modularizedStructure.computed) {
+            // Modularized
+            config.push(['include', 'nginxconfig.io/letsencrypt.conf']);
+        } else {
+            // Unified
+            config.push(...Object.entries(letsEncryptConf(global)));
+        }
+
+        config.push(['location /', {
+            return: `301 https://${redirectDomain ? redirectDomain : domainName}$request_uri`,
+        }]);
+    } else {
+        // Custom cert
+        config.push(['return', `301 https://${redirectDomain ? redirectDomain : domainName}$request_uri`]);
+    }
+
+    return config;
+}
+
 export default (domain, domains, global) => {
     // Use kv so we can use the same key multiple times
     const config = [];
@@ -311,35 +342,18 @@ export default (domain, domains, global) => {
 
     // HTTP redirect
     if (domain.https.forceHttps.computed) {
-        // Build the server config on its own before adding it to the parent config
-        const redirectConfig = [];
-
-        redirectConfig.push(...httpListen(domain));
-        redirectConfig.push(['server_name',
-            `${domain.server.redirectSubdomains.computed ? '.' : ''}${domain.server.domain.computed}`]);
-
-        if (domain.https.certType.computed === 'letsEncrypt') {
-            // Let's encrypt
-
-            if (global.tools.modularizedStructure.computed) {
-                // Modularized
-                redirectConfig.push(['include', 'nginxconfig.io/letsencrypt.conf']);
-            } else {
-                // Unified
-                redirectConfig.push(...Object.entries(letsEncryptConf(global)));
-            }
-
-            redirectConfig.push(['location /', {
-                return: `301 https://${domain.server.wwwSubdomain.computed ? 'www.' : ''}${domain.server.domain.computed}$request_uri`,
-            }]);
-        } else {
-            // Custom cert
-            redirectConfig.push(['return', `301 https://${domain.server.wwwSubdomain.computed ? 'www.' : ''}${domain.server.domain.computed}$request_uri`]);
-        }
-
         // Add the redirect config to the parent config now its built
         config.push(['# HTTP redirect', '']);
-        config.push(['server', redirectConfig]);
+        if (domain.server.wwwSubdomain.computed && !domain.server.redirectSubdomains.computed) {
+            config.push(['server', httpRedirectConfig(domain, global, domain.server.domain.computed, `www.${domain.server.domain.computed}`)]);
+            config.push(['server', httpRedirectConfig(domain, global, `www.${domain.server.domain.computed}`)]);
+        }
+        if (domain.server.cdnSubdomain.computed) {
+            config.push(['server', httpRedirectConfig(domain, global, `cdn.${domain.server.domain.computed}`)]);
+        }
+        if (domain.server.redirectSubdomains.computed) {
+            config.push(['server', httpRedirectConfig(domain, global, `.${domain.server.domain.computed}`, `${domain.server.wwwSubdomain.computed ? 'www.' : '' }${domain.server.domain.computed}`)]);
+        }
     }
 
     return config;

--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -86,8 +86,7 @@ const listenConfig = domain => {
 };
 
 
-function httpRedirectConfig(domain, global, domainName, redirectDomain)
-{
+const httpRedirectConfig = (domain, global, domainName, redirectDomain) => {
     // Build the server config on its own before adding it to the parent config
     const config = [];
 


### PR DESCRIPTION
## Type of Change
Fixes HTTP redirects

LetsEncrypt currently can't verify certificates on subdomains such as www. and cdn. due to the conf file only listening on 443 for the subdomains.

Here is a config showing this: https://www.digitalocean.com/community/tools/nginx?domains.0.server.wwwSubdomain=true&domains.0.server.cdnSubdomain=true&domains.0.server.redirectSubdomains=false

It also prevents the CDN subdomain from being redirected to www when both Subdomain Redirects and CDN subdomain is enabled as shown in this config: https://www.digitalocean.com/community/tools/nginx?domains.0.server.wwwSubdomain=true&domains.0.server.cdnSubdomain=true

## What issue does this relate to?
None, I haven't created one.

### What should this PR do?
This PR should allow letsencrypt to supply certificates for subdomains and prevent cdn subdomain from redirecting to www

### What are the acceptance criteria?
Check letsencrypt successfully supplies certificates for the base domain, www domain and cdn domain when HTTPS is enabled.
Check redirects HTTP to HTTPS on base domain, www domain and cdn domain.

