### PR TITLE
Fix HTTP to HTTPS redirect without subdomains

### DIFF
--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -346,6 +346,8 @@ export default (domain, domains, global) => {
         if (domain.server.wwwSubdomain.computed && !domain.server.redirectSubdomains.computed) {
             config.push(['server', httpRedirectConfig(domain, global, domain.server.domain.computed, `www.${domain.server.domain.computed}`)]);
             config.push(['server', httpRedirectConfig(domain, global, `www.${domain.server.domain.computed}`)]);
+        } else if (!domain.server.wwwSubdomain.computed && !domain.server.redirectSubdomains.computed) {
+            config.push(['server', httpRedirectConfig(domain, global, domain.server.domain.computed)]);
         }
         if (domain.server.cdnSubdomain.computed) {
             config.push(['server', httpRedirectConfig(domain, global, `cdn.${domain.server.domain.computed}`)]);


### PR DESCRIPTION
## Type of Change
<!-- What part of the source are you modifying? Remove the irrelevant options. -->

- **Tool Source:** JS

## What issue does this relate to?
<!-- Use a GitHub keyword ('resolves #xx', 'fixes #xx', 'closes #xx') to automatically close the relevant issue. -->
Addresses issues later discussed in #169 that were not the original issue.

### What should this PR do?
<!-- Write a quick bullet point summary of the changes this PR should be making. -->
Generate HTTP Redirect rules for domain entries without a www subdomain and without subdomain redirects.

### What are the acceptance criteria?
<!-- Write a list of what should reviewers be checking before they approve this PR. -->
<!-- If there are UI changes, include before and after screenshots in a table for comparison. -->
Verify that a domain entry with "www subdomain" disabled, "Redirect subdomains" disabled, and "Force HTTPS" enabled generates valid "HTTP Redirect" rules.
