### PR TITLE
Fix wordpress rules, removing incorrect CVE fix

### DIFF
--- a/src/nginxconfig/generators/conf/wordpress.conf.js
+++ b/src/nginxconfig/generators/conf/wordpress.conf.js
@@ -50,11 +50,6 @@ export default global => {
         deny: 'all',
     };
 
-    config['# WordPress: deny scripts and styles concat'] = '';
-    config['location ~* \\/wp-admin\\/load-(?:scripts|styles)\\.php'] = {
-        deny: 'all',
-    };
-
     config['# WordPress: deny general stuff'] = '';
     config['location ~* ^/(?:xmlrpc\\.php|wp-links-opml\\.php|wp-config\\.php|wp-config-sample\\.php|wp-comments-post\\.php|readme\\.html|license\\.txt)$'] = {
         deny: 'all',


### PR DESCRIPTION
## Type of Change

- **Tool Source:** JS, WordPress config generator

## What issue does this relate to?

Fixes #182

### What should this PR do?

Removes the incorrect blocking rule

### What are the acceptance criteria?

Block rule is removed