### PR TITLE
Always use absolute url for query params

### DIFF
--- a/src/nginxconfig/templates/global_sections/tools.vue
+++ b/src/nginxconfig/templates/global_sections/tools.vue
@@ -200,7 +200,7 @@ THE SOFTWARE.
         watch: {
             // When the share link changes, update the site query
             shareQuery(query) {
-                window.history.replaceState({}, '', query || window.location.pathname);
+                window.history.replaceState({}, '', `${window.location.pathname}${query || ''}`);
             },
             // Disable symlink if modularized structure is disabled
             '$props.data.modularizedStructure': {


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue: global tools

## What issue does this relate to?

N/A

### What should this PR do?

Ensure we always use an absolute URL when pushing to history -- if we switch from `?` to `#?`, without the pathname, it'll append the `#?` params to the existing `?` params.

### What are the acceptance criteria?

- Applying settings to a domian updates the tool correctly
- Resetting the domain to the defaults removes the query params correctly