### PR TITLE
Remove extra quotes from website HSTS

### DIFF
--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -154,7 +154,7 @@ export default (domain, domains, global) => {
     if (!commonHsts(domains) && domain.https.hsts.computed) {
         serverConfig.push(['# HSTS', '']);
         serverConfig.push(['add_header Strict-Transport-Security',
-            `'"max-age=31536000${domain.https.hstsSubdomains.computed ? '; includeSubDomains' : ''}${domain.https.hstsPreload.computed ? '; preload' : ''}" always'`]);
+            `"max-age=31536000${domain.https.hstsSubdomains.computed ? '; includeSubDomains' : ''}${domain.https.hstsPreload.computed ? '; preload' : ''}" always`]);
     }
 
     // Security


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Config generator

## What issue does this relate to?

Fixes #195

### What should this PR do?

Removes extra quotes that were present in the HSTS header for a single website.

### What are the acceptance criteria?

Have two websites in the tool one with HSTS enabled and one without.

The HSTS header in the config file for the site with it enabled should not have extra single quotes around it.