### PR TITLE
Add analytics event for langauge selection

### DIFF
--- a/src/nginxconfig/templates/app.vue
+++ b/src/nginxconfig/templates/app.vue
@@ -213,7 +213,11 @@ THE SOFTWARE.
 
                     // Update the locale
                     this.$i18n.locale = data.computed;
-                    analytics('set_language', 'Language', data.computed);
+
+                    // Analytics
+                    const pack = data.computed.match(/^([a-z]+)([A-Z]*)$/).slice(1)
+                        .map(x => x.toLowerCase()).filter(x => !!x).join('_');
+                    analytics(`set_language${pack}`, 'Language');
                 },
                 deep: true,
             },

--- a/src/nginxconfig/templates/app.vue
+++ b/src/nginxconfig/templates/app.vue
@@ -217,7 +217,7 @@ THE SOFTWARE.
                     // Analytics
                     const pack = data.computed.match(/^([a-z]+)([A-Z]*)$/).slice(1)
                         .map(x => x.toLowerCase()).filter(x => !!x).join('_');
-                    analytics(`set_language${pack}`, 'Language');
+                    analytics(`set_language_${pack}`, 'Language');
                 },
                 deep: true,
             },

--- a/src/nginxconfig/templates/app.vue
+++ b/src/nginxconfig/templates/app.vue
@@ -213,6 +213,7 @@ THE SOFTWARE.
 
                     // Update the locale
                     this.$i18n.locale = data.computed;
+                    analytics('set_language', 'Language', data.computed);
                 },
                 deep: true,
             },


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue

## What issue does this relate to?

N/A

### What should this PR do?

Now that we've introduced multiple languages, we should fire an analytics event when a language is set so that we can better understand how users are using the tool.

### What are the acceptance criteria?

Event fires when language is set via dropdown or via URL param.