### PR TITLE
Add Droplet & contribution callouts

### DIFF
--- a/src/nginxconfig/i18n/en/templates/callouts/contribute.js
+++ b/src/nginxconfig/i18n/en/templates/callouts/contribute.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import droplet from './droplet';
-import contribute from './contribute';
-
-export default { droplet, contribute };
+export default {
+    wantToContributeChanges: '👋 Want to request new features, contribute changes, or translate the tool into a new language?',
+    getInvolvedOnGitHub: 'Get involved on GitHub',
+};

--- a/src/nginxconfig/i18n/en/templates/callouts/droplet.js
+++ b/src/nginxconfig/i18n/en/templates/callouts/droplet.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,33 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-$header: #0071fe;
-$highlight: #f2c94c;
-$callout: #f3f5f9;
-@import "~do-bulma/src/style";
-
-.do-bulma {
-  @import "../../../build/prism";
-
-  $pretty--color-dark: $primary;
-  $pretty--color-default: $primary;
-  @import "~pretty-checkbox/src/pretty-checkbox";
-
-  $vs-border-color: $border;
-  $vs-border-radius: $border-radius;
-  $vs-dropdown-box-shadow: 0 2px 4px rgba($dark-blue, .06);
-  $vs-state-active-bg: $primary;
-  @import "~vue-select/src/scss/vue-select";
-
-  @import "header";
-  @import "tabs";
-  @import "panel";
-  @import "fields";
-  @import "vue-select";
-  @import "modals";
-  @import "callout";
-  @import "setup";
-  @import "code";
-  @import "files";
-  @import "footer";
-}
+export default {
+    lookingForAPlaceToDeploy: '👋 Looking for a place to deploy your new configuration?',
+    tryOutDigitalOceansDroplet: 'Try out DigitalOcean\'s LEMP Droplet with NGINX',
+};

--- a/src/nginxconfig/i18n/en/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/en/templates/callouts/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,33 +24,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-$header: #0071fe;
-$highlight: #f2c94c;
-$callout: #f3f5f9;
-@import "~do-bulma/src/style";
+import droplet from './droplet';
 
-.do-bulma {
-  @import "../../../build/prism";
-
-  $pretty--color-dark: $primary;
-  $pretty--color-default: $primary;
-  @import "~pretty-checkbox/src/pretty-checkbox";
-
-  $vs-border-color: $border;
-  $vs-border-radius: $border-radius;
-  $vs-dropdown-box-shadow: 0 2px 4px rgba($dark-blue, .06);
-  $vs-state-active-bg: $primary;
-  @import "~vue-select/src/scss/vue-select";
-
-  @import "header";
-  @import "tabs";
-  @import "panel";
-  @import "fields";
-  @import "vue-select";
-  @import "modals";
-  @import "callout";
-  @import "setup";
-  @import "code";
-  @import "files";
-  @import "footer";
-}
+export default { droplet };

--- a/src/nginxconfig/i18n/en/templates/index.js
+++ b/src/nginxconfig/i18n/en/templates/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -30,5 +30,6 @@ import footer from './footer';
 import domainSections from './domain_sections';
 import globalSections from './global_sections';
 import setupSections from './setup_sections';
+import callouts from './callouts';
 
-export default { app, setup, footer, domainSections, globalSections, setupSections };
+export default { app, setup, footer, domainSections, globalSections, setupSections, callouts };

--- a/src/nginxconfig/i18n/fr/templates/callouts/contribute.js
+++ b/src/nginxconfig/i18n/fr/templates/callouts/contribute.js
@@ -24,75 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-.callout {
-  background: $callout;
-  border-radius: $border-radius;
-  margin: 2rem .5rem 1rem;
-  padding: 1.875rem 1.875rem 1.5rem;
-  transition: opacity $transition;
-
-  &.floating {
-    bottom: 0;
-    box-shadow: inset 0 0 0 $border-size $border-color;
-    max-width: calc(100% - 1rem);
-    position: fixed;
-    right: 0;
-    width: 22rem;
-    z-index: 100;
-
-    .close {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      margin: 0 0 1.25rem;
-
-      p {
-        flex-grow: 1;
-        margin: 0 .5rem 0 0;
-      }
-
-      a {
-        color: $muted;
-        margin: 0 .5rem;
-        text-decoration: none;
-        transition: color $transition;
-
-        &:hover {
-          color: $text;
-        }
-      }
-    }
-
-    p {
-      @include sailec-regular;
-    }
-
-    .button {
-      display: block;
-      height: 3rem;
-      line-height: 3rem;
-    }
-  }
-
-  p {
-    @include sailec-medium;
-
-    font-size: 15px;
-    margin: 0;
-    text-align: left;
-
-    a {
-      border-bottom: $border-size dotted $primary;
-      padding: 0 0 $border-size;
-      text-decoration: none;
-
-      &:hover {
-        border-bottom-color: $primary-hover;
-      }
-
-      + i {
-        margin: 0 0 0 .25rem;
-      }
-    }
-  }
-}
+export default {
+    wantToContributeChanges: '👋 Want to request new features, contribute changes, or translate the tool into a new language?', // TODO: translate
+    getInvolvedOnGitHub: 'Get involved on GitHub', // TODO: translate
+};

--- a/src/nginxconfig/i18n/fr/templates/callouts/droplet.js
+++ b/src/nginxconfig/i18n/fr/templates/callouts/droplet.js
@@ -24,75 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-.callout {
-  background: $callout;
-  border-radius: $border-radius;
-  margin: 2rem .5rem 1rem;
-  padding: 1.875rem 1.875rem 1.5rem;
-  transition: opacity $transition;
-
-  &.floating {
-    bottom: 0;
-    box-shadow: inset 0 0 0 $border-size $border-color;
-    max-width: calc(100% - 1rem);
-    position: fixed;
-    right: 0;
-    width: 22rem;
-    z-index: 100;
-
-    .close {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      margin: 0 0 1.25rem;
-
-      p {
-        flex-grow: 1;
-        margin: 0 .5rem 0 0;
-      }
-
-      a {
-        color: $muted;
-        margin: 0 .5rem;
-        text-decoration: none;
-        transition: color $transition;
-
-        &:hover {
-          color: $text;
-        }
-      }
-    }
-
-    p {
-      @include sailec-regular;
-    }
-
-    .button {
-      display: block;
-      height: 3rem;
-      line-height: 3rem;
-    }
-  }
-
-  p {
-    @include sailec-medium;
-
-    font-size: 15px;
-    margin: 0;
-    text-align: left;
-
-    a {
-      border-bottom: $border-size dotted $primary;
-      padding: 0 0 $border-size;
-      text-decoration: none;
-
-      &:hover {
-        border-bottom-color: $primary-hover;
-      }
-
-      + i {
-        margin: 0 0 0 .25rem;
-      }
-    }
-  }
-}
+export default {
+    lookingForAPlaceToDeploy: '👋 Looking for a place to deploy your new configuration?', // TODO: translate
+    tryOutDigitalOceansDroplet: 'Try out DigitalOcean\'s LEMP Droplet with NGINX', // TODO: translate
+};

--- a/src/nginxconfig/i18n/fr/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/fr/templates/callouts/index.js
@@ -24,75 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-.callout {
-  background: $callout;
-  border-radius: $border-radius;
-  margin: 2rem .5rem 1rem;
-  padding: 1.875rem 1.875rem 1.5rem;
-  transition: opacity $transition;
+import droplet from './droplet';
+import contribute from './contribute';
 
-  &.floating {
-    bottom: 0;
-    box-shadow: inset 0 0 0 $border-size $border-color;
-    max-width: calc(100% - 1rem);
-    position: fixed;
-    right: 0;
-    width: 22rem;
-    z-index: 100;
-
-    .close {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      margin: 0 0 1.25rem;
-
-      p {
-        flex-grow: 1;
-        margin: 0 .5rem 0 0;
-      }
-
-      a {
-        color: $muted;
-        margin: 0 .5rem;
-        text-decoration: none;
-        transition: color $transition;
-
-        &:hover {
-          color: $text;
-        }
-      }
-    }
-
-    p {
-      @include sailec-regular;
-    }
-
-    .button {
-      display: block;
-      height: 3rem;
-      line-height: 3rem;
-    }
-  }
-
-  p {
-    @include sailec-medium;
-
-    font-size: 15px;
-    margin: 0;
-    text-align: left;
-
-    a {
-      border-bottom: $border-size dotted $primary;
-      padding: 0 0 $border-size;
-      text-decoration: none;
-
-      &:hover {
-        border-bottom-color: $primary-hover;
-      }
-
-      + i {
-        margin: 0 0 0 .25rem;
-      }
-    }
-  }
-}
+export default { droplet, contribute };

--- a/src/nginxconfig/i18n/fr/templates/index.js
+++ b/src/nginxconfig/i18n/fr/templates/index.js
@@ -30,5 +30,6 @@ import footer from './footer';
 import domainSections from './domain_sections';
 import globalSections from './global_sections';
 import setupSections from './setup_sections';
+import callouts from './callouts';
 
-export default { app, setup, footer, domainSections, globalSections, setupSections };
+export default { app, setup, footer, domainSections, globalSections, setupSections, callouts };

--- a/src/nginxconfig/i18n/pt-br/templates/callouts/contribute.js
+++ b/src/nginxconfig/i18n/pt-br/templates/callouts/contribute.js
@@ -24,75 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-.callout {
-  background: $callout;
-  border-radius: $border-radius;
-  margin: 2rem .5rem 1rem;
-  padding: 1.875rem 1.875rem 1.5rem;
-  transition: opacity $transition;
-
-  &.floating {
-    bottom: 0;
-    box-shadow: inset 0 0 0 $border-size $border-color;
-    max-width: calc(100% - 1rem);
-    position: fixed;
-    right: 0;
-    width: 22rem;
-    z-index: 100;
-
-    .close {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      margin: 0 0 1.25rem;
-
-      p {
-        flex-grow: 1;
-        margin: 0 .5rem 0 0;
-      }
-
-      a {
-        color: $muted;
-        margin: 0 .5rem;
-        text-decoration: none;
-        transition: color $transition;
-
-        &:hover {
-          color: $text;
-        }
-      }
-    }
-
-    p {
-      @include sailec-regular;
-    }
-
-    .button {
-      display: block;
-      height: 3rem;
-      line-height: 3rem;
-    }
-  }
-
-  p {
-    @include sailec-medium;
-
-    font-size: 15px;
-    margin: 0;
-    text-align: left;
-
-    a {
-      border-bottom: $border-size dotted $primary;
-      padding: 0 0 $border-size;
-      text-decoration: none;
-
-      &:hover {
-        border-bottom-color: $primary-hover;
-      }
-
-      + i {
-        margin: 0 0 0 .25rem;
-      }
-    }
-  }
-}
+export default {
+    wantToContributeChanges: '👋 Want to request new features, contribute changes, or translate the tool into a new language?', // TODO: translate
+    getInvolvedOnGitHub: 'Get involved on GitHub', // TODO: translate
+};

--- a/src/nginxconfig/i18n/pt-br/templates/callouts/droplet.js
+++ b/src/nginxconfig/i18n/pt-br/templates/callouts/droplet.js
@@ -24,75 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-.callout {
-  background: $callout;
-  border-radius: $border-radius;
-  margin: 2rem .5rem 1rem;
-  padding: 1.875rem 1.875rem 1.5rem;
-  transition: opacity $transition;
-
-  &.floating {
-    bottom: 0;
-    box-shadow: inset 0 0 0 $border-size $border-color;
-    max-width: calc(100% - 1rem);
-    position: fixed;
-    right: 0;
-    width: 22rem;
-    z-index: 100;
-
-    .close {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      margin: 0 0 1.25rem;
-
-      p {
-        flex-grow: 1;
-        margin: 0 .5rem 0 0;
-      }
-
-      a {
-        color: $muted;
-        margin: 0 .5rem;
-        text-decoration: none;
-        transition: color $transition;
-
-        &:hover {
-          color: $text;
-        }
-      }
-    }
-
-    p {
-      @include sailec-regular;
-    }
-
-    .button {
-      display: block;
-      height: 3rem;
-      line-height: 3rem;
-    }
-  }
-
-  p {
-    @include sailec-medium;
-
-    font-size: 15px;
-    margin: 0;
-    text-align: left;
-
-    a {
-      border-bottom: $border-size dotted $primary;
-      padding: 0 0 $border-size;
-      text-decoration: none;
-
-      &:hover {
-        border-bottom-color: $primary-hover;
-      }
-
-      + i {
-        margin: 0 0 0 .25rem;
-      }
-    }
-  }
-}
+export default {
+    lookingForAPlaceToDeploy: '👋 Looking for a place to deploy your new configuration?', // TODO: translate
+    tryOutDigitalOceansDroplet: 'Try out DigitalOcean\'s LEMP Droplet with NGINX', // TODO: translate
+};

--- a/src/nginxconfig/i18n/pt-br/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/pt-br/templates/callouts/index.js
@@ -24,75 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-.callout {
-  background: $callout;
-  border-radius: $border-radius;
-  margin: 2rem .5rem 1rem;
-  padding: 1.875rem 1.875rem 1.5rem;
-  transition: opacity $transition;
+import droplet from './droplet';
+import contribute from './contribute';
 
-  &.floating {
-    bottom: 0;
-    box-shadow: inset 0 0 0 $border-size $border-color;
-    max-width: calc(100% - 1rem);
-    position: fixed;
-    right: 0;
-    width: 22rem;
-    z-index: 100;
-
-    .close {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      margin: 0 0 1.25rem;
-
-      p {
-        flex-grow: 1;
-        margin: 0 .5rem 0 0;
-      }
-
-      a {
-        color: $muted;
-        margin: 0 .5rem;
-        text-decoration: none;
-        transition: color $transition;
-
-        &:hover {
-          color: $text;
-        }
-      }
-    }
-
-    p {
-      @include sailec-regular;
-    }
-
-    .button {
-      display: block;
-      height: 3rem;
-      line-height: 3rem;
-    }
-  }
-
-  p {
-    @include sailec-medium;
-
-    font-size: 15px;
-    margin: 0;
-    text-align: left;
-
-    a {
-      border-bottom: $border-size dotted $primary;
-      padding: 0 0 $border-size;
-      text-decoration: none;
-
-      &:hover {
-        border-bottom-color: $primary-hover;
-      }
-
-      + i {
-        margin: 0 0 0 .25rem;
-      }
-    }
-  }
-}
+export default { droplet, contribute };

--- a/src/nginxconfig/i18n/pt-br/templates/index.js
+++ b/src/nginxconfig/i18n/pt-br/templates/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -30,5 +30,6 @@ import footer from './footer';
 import domainSections from './domain_sections';
 import globalSections from './global_sections';
 import setupSections from './setup_sections';
+import callouts from './callouts';
 
-export default { app, setup, footer, domainSections, globalSections, setupSections };
+export default { app, setup, footer, domainSections, globalSections, setupSections, callouts };

--- a/src/nginxconfig/i18n/zh-cn/templates/callouts/contribute.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/callouts/contribute.js
@@ -24,75 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-.callout {
-  background: $callout;
-  border-radius: $border-radius;
-  margin: 2rem .5rem 1rem;
-  padding: 1.875rem 1.875rem 1.5rem;
-  transition: opacity $transition;
-
-  &.floating {
-    bottom: 0;
-    box-shadow: inset 0 0 0 $border-size $border-color;
-    max-width: calc(100% - 1rem);
-    position: fixed;
-    right: 0;
-    width: 22rem;
-    z-index: 100;
-
-    .close {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      margin: 0 0 1.25rem;
-
-      p {
-        flex-grow: 1;
-        margin: 0 .5rem 0 0;
-      }
-
-      a {
-        color: $muted;
-        margin: 0 .5rem;
-        text-decoration: none;
-        transition: color $transition;
-
-        &:hover {
-          color: $text;
-        }
-      }
-    }
-
-    p {
-      @include sailec-regular;
-    }
-
-    .button {
-      display: block;
-      height: 3rem;
-      line-height: 3rem;
-    }
-  }
-
-  p {
-    @include sailec-medium;
-
-    font-size: 15px;
-    margin: 0;
-    text-align: left;
-
-    a {
-      border-bottom: $border-size dotted $primary;
-      padding: 0 0 $border-size;
-      text-decoration: none;
-
-      &:hover {
-        border-bottom-color: $primary-hover;
-      }
-
-      + i {
-        margin: 0 0 0 .25rem;
-      }
-    }
-  }
-}
+export default {
+    wantToContributeChanges: '👋 Want to request new features, contribute changes, or translate the tool into a new language?', // TODO: translate
+    getInvolvedOnGitHub: 'Get involved on GitHub', // TODO: translate
+};

--- a/src/nginxconfig/i18n/zh-cn/templates/callouts/droplet.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/callouts/droplet.js
@@ -24,75 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-.callout {
-  background: $callout;
-  border-radius: $border-radius;
-  margin: 2rem .5rem 1rem;
-  padding: 1.875rem 1.875rem 1.5rem;
-  transition: opacity $transition;
-
-  &.floating {
-    bottom: 0;
-    box-shadow: inset 0 0 0 $border-size $border-color;
-    max-width: calc(100% - 1rem);
-    position: fixed;
-    right: 0;
-    width: 22rem;
-    z-index: 100;
-
-    .close {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      margin: 0 0 1.25rem;
-
-      p {
-        flex-grow: 1;
-        margin: 0 .5rem 0 0;
-      }
-
-      a {
-        color: $muted;
-        margin: 0 .5rem;
-        text-decoration: none;
-        transition: color $transition;
-
-        &:hover {
-          color: $text;
-        }
-      }
-    }
-
-    p {
-      @include sailec-regular;
-    }
-
-    .button {
-      display: block;
-      height: 3rem;
-      line-height: 3rem;
-    }
-  }
-
-  p {
-    @include sailec-medium;
-
-    font-size: 15px;
-    margin: 0;
-    text-align: left;
-
-    a {
-      border-bottom: $border-size dotted $primary;
-      padding: 0 0 $border-size;
-      text-decoration: none;
-
-      &:hover {
-        border-bottom-color: $primary-hover;
-      }
-
-      + i {
-        margin: 0 0 0 .25rem;
-      }
-    }
-  }
-}
+export default {
+    lookingForAPlaceToDeploy: '👋 Looking for a place to deploy your new configuration?', // TODO: translate
+    tryOutDigitalOceansDroplet: 'Try out DigitalOcean\'s LEMP Droplet with NGINX', // TODO: translate
+};

--- a/src/nginxconfig/i18n/zh-cn/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/callouts/index.js
@@ -24,75 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-.callout {
-  background: $callout;
-  border-radius: $border-radius;
-  margin: 2rem .5rem 1rem;
-  padding: 1.875rem 1.875rem 1.5rem;
-  transition: opacity $transition;
+import droplet from './droplet';
+import contribute from './contribute';
 
-  &.floating {
-    bottom: 0;
-    box-shadow: inset 0 0 0 $border-size $border-color;
-    max-width: calc(100% - 1rem);
-    position: fixed;
-    right: 0;
-    width: 22rem;
-    z-index: 100;
-
-    .close {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      margin: 0 0 1.25rem;
-
-      p {
-        flex-grow: 1;
-        margin: 0 .5rem 0 0;
-      }
-
-      a {
-        color: $muted;
-        margin: 0 .5rem;
-        text-decoration: none;
-        transition: color $transition;
-
-        &:hover {
-          color: $text;
-        }
-      }
-    }
-
-    p {
-      @include sailec-regular;
-    }
-
-    .button {
-      display: block;
-      height: 3rem;
-      line-height: 3rem;
-    }
-  }
-
-  p {
-    @include sailec-medium;
-
-    font-size: 15px;
-    margin: 0;
-    text-align: left;
-
-    a {
-      border-bottom: $border-size dotted $primary;
-      padding: 0 0 $border-size;
-      text-decoration: none;
-
-      &:hover {
-        border-bottom-color: $primary-hover;
-      }
-
-      + i {
-        margin: 0 0 0 .25rem;
-      }
-    }
-  }
-}
+export default { droplet, contribute };

--- a/src/nginxconfig/i18n/zh-cn/templates/index.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -30,5 +30,6 @@ import footer from './footer';
 import domainSections from './domain_sections';
 import globalSections from './global_sections';
 import setupSections from './setup_sections';
+import callouts from './callouts';
 
-export default { app, setup, footer, domainSections, globalSections, setupSections };
+export default { app, setup, footer, domainSections, globalSections, setupSections, callouts };

--- a/src/nginxconfig/i18n/zh-tw/templates/callouts/contribute.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/callouts/contribute.js
@@ -24,75 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-.callout {
-  background: $callout;
-  border-radius: $border-radius;
-  margin: 2rem .5rem 1rem;
-  padding: 1.875rem 1.875rem 1.5rem;
-  transition: opacity $transition;
-
-  &.floating {
-    bottom: 0;
-    box-shadow: inset 0 0 0 $border-size $border-color;
-    max-width: calc(100% - 1rem);
-    position: fixed;
-    right: 0;
-    width: 22rem;
-    z-index: 100;
-
-    .close {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      margin: 0 0 1.25rem;
-
-      p {
-        flex-grow: 1;
-        margin: 0 .5rem 0 0;
-      }
-
-      a {
-        color: $muted;
-        margin: 0 .5rem;
-        text-decoration: none;
-        transition: color $transition;
-
-        &:hover {
-          color: $text;
-        }
-      }
-    }
-
-    p {
-      @include sailec-regular;
-    }
-
-    .button {
-      display: block;
-      height: 3rem;
-      line-height: 3rem;
-    }
-  }
-
-  p {
-    @include sailec-medium;
-
-    font-size: 15px;
-    margin: 0;
-    text-align: left;
-
-    a {
-      border-bottom: $border-size dotted $primary;
-      padding: 0 0 $border-size;
-      text-decoration: none;
-
-      &:hover {
-        border-bottom-color: $primary-hover;
-      }
-
-      + i {
-        margin: 0 0 0 .25rem;
-      }
-    }
-  }
-}
+export default {
+    wantToContributeChanges: '👋 Want to request new features, contribute changes, or translate the tool into a new language?', // TODO: translate
+    getInvolvedOnGitHub: 'Get involved on GitHub', // TODO: translate
+};

--- a/src/nginxconfig/i18n/zh-tw/templates/callouts/droplet.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/callouts/droplet.js
@@ -24,75 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-.callout {
-  background: $callout;
-  border-radius: $border-radius;
-  margin: 2rem .5rem 1rem;
-  padding: 1.875rem 1.875rem 1.5rem;
-  transition: opacity $transition;
-
-  &.floating {
-    bottom: 0;
-    box-shadow: inset 0 0 0 $border-size $border-color;
-    max-width: calc(100% - 1rem);
-    position: fixed;
-    right: 0;
-    width: 22rem;
-    z-index: 100;
-
-    .close {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      margin: 0 0 1.25rem;
-
-      p {
-        flex-grow: 1;
-        margin: 0 .5rem 0 0;
-      }
-
-      a {
-        color: $muted;
-        margin: 0 .5rem;
-        text-decoration: none;
-        transition: color $transition;
-
-        &:hover {
-          color: $text;
-        }
-      }
-    }
-
-    p {
-      @include sailec-regular;
-    }
-
-    .button {
-      display: block;
-      height: 3rem;
-      line-height: 3rem;
-    }
-  }
-
-  p {
-    @include sailec-medium;
-
-    font-size: 15px;
-    margin: 0;
-    text-align: left;
-
-    a {
-      border-bottom: $border-size dotted $primary;
-      padding: 0 0 $border-size;
-      text-decoration: none;
-
-      &:hover {
-        border-bottom-color: $primary-hover;
-      }
-
-      + i {
-        margin: 0 0 0 .25rem;
-      }
-    }
-  }
-}
+export default {
+    lookingForAPlaceToDeploy: '👋 Looking for a place to deploy your new configuration?', // TODO: translate
+    tryOutDigitalOceansDroplet: 'Try out DigitalOcean\'s LEMP Droplet with NGINX', // TODO: translate
+};

--- a/src/nginxconfig/i18n/zh-tw/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/callouts/index.js
@@ -24,75 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-.callout {
-  background: $callout;
-  border-radius: $border-radius;
-  margin: 2rem .5rem 1rem;
-  padding: 1.875rem 1.875rem 1.5rem;
-  transition: opacity $transition;
+import droplet from './droplet';
+import contribute from './contribute';
 
-  &.floating {
-    bottom: 0;
-    box-shadow: inset 0 0 0 $border-size $border-color;
-    max-width: calc(100% - 1rem);
-    position: fixed;
-    right: 0;
-    width: 22rem;
-    z-index: 100;
-
-    .close {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      margin: 0 0 1.25rem;
-
-      p {
-        flex-grow: 1;
-        margin: 0 .5rem 0 0;
-      }
-
-      a {
-        color: $muted;
-        margin: 0 .5rem;
-        text-decoration: none;
-        transition: color $transition;
-
-        &:hover {
-          color: $text;
-        }
-      }
-    }
-
-    p {
-      @include sailec-regular;
-    }
-
-    .button {
-      display: block;
-      height: 3rem;
-      line-height: 3rem;
-    }
-  }
-
-  p {
-    @include sailec-medium;
-
-    font-size: 15px;
-    margin: 0;
-    text-align: left;
-
-    a {
-      border-bottom: $border-size dotted $primary;
-      padding: 0 0 $border-size;
-      text-decoration: none;
-
-      &:hover {
-        border-bottom-color: $primary-hover;
-      }
-
-      + i {
-        margin: 0 0 0 .25rem;
-      }
-    }
-  }
-}
+export default { droplet, contribute };

--- a/src/nginxconfig/i18n/zh-tw/templates/index.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -30,5 +30,6 @@ import footer from './footer';
 import domainSections from './domain_sections';
 import globalSections from './global_sections';
 import setupSections from './setup_sections';
+import callouts from './callouts';
 
-export default { app, setup, footer, domainSections, globalSections, setupSections };
+export default { app, setup, footer, domainSections, globalSections, setupSections, callouts };

--- a/src/nginxconfig/scss/_callout.scss
+++ b/src/nginxconfig/scss/_callout.scss
@@ -38,6 +38,7 @@ THE SOFTWARE.
     width: 22rem;
     max-width: calc(100% - 1rem);
     box-shadow: inset 0 0 0 $border-size $border-color;
+    z-index: 100;
 
     .close {
       display: flex;

--- a/src/nginxconfig/scss/_callout.scss
+++ b/src/nginxconfig/scss/_callout.scss
@@ -9,22 +9,41 @@
     position: fixed;
     bottom: 0;
     right: 0;
-    width: 20rem;
+    width: 22rem;
     max-width: calc(100% - 1rem);
     box-shadow: inset 0 0 0 $border-size $border-color;
 
+    .close {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: nowrap;
+      margin: 0 0 1.25rem;
+
+      p {
+        flex-grow: 1;
+        margin: 0 .5rem 0 0;
+      }
+
+      a {
+        color: $muted;
+        margin: 0 .5rem;
+        text-decoration: none;
+        transition: color $transition;
+
+        &:hover {
+          color: $text;
+        }
+      }
+    }
+
     p {
       @include sailec-regular;
+    }
 
-      + p {
-        margin: 1.25rem 0 0;
-      }
-
-      .button {
-        display: block;
-        height: 3rem;
-        line-height: 3rem;
-      }
+    .button {
+      display: block;
+      height: 3rem;
+      line-height: 3rem;
     }
   }
 

--- a/src/nginxconfig/scss/_callout.scss
+++ b/src/nginxconfig/scss/_callout.scss
@@ -4,6 +4,29 @@
   margin: 2rem .5rem 1rem;
   padding: 1.875rem 1.875rem 1.5rem;
 
+  &.floating {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    width: 20rem;
+    max-width: calc(100% - 1rem);
+    box-shadow: inset 0 0 0 $border-size $border-color;
+
+    p {
+      @include sailec-regular;
+
+      + p {
+        margin: 1.25rem 0 0;
+      }
+
+      .button {
+        display: block;
+        height: 3rem;
+        line-height: 3rem;
+      }
+    }
+  }
+
   p {
     @include sailec-medium;
 
@@ -13,8 +36,8 @@
 
     a {
       text-decoration: none;
-      padding: 0 0 1px;
-      border-bottom: 1px dotted $primary;
+      padding: 0 0 $border-size;
+      border-bottom: $border-size dotted $primary;
 
       &:hover {
         border-bottom-color: $primary-hover;

--- a/src/nginxconfig/scss/_callout.scss
+++ b/src/nginxconfig/scss/_callout.scss
@@ -1,0 +1,28 @@
+.callout {
+  background: $callout;
+  border-radius: $border-radius;
+  margin: 2rem .5rem 1rem;
+  padding: 1.875rem 1.875rem 1.5rem;
+
+  p {
+    @include sailec-medium;
+
+    margin: 0;
+    text-align: left;
+    font-size: 15px;
+
+    a {
+      text-decoration: none;
+      padding: 0 0 1px;
+      border-bottom: 1px dotted $primary;
+
+      &:hover {
+        border-bottom-color: $primary-hover;
+      }
+
+      + i {
+        margin: 0 0 0 .25rem;
+      }
+    }
+  }
+}

--- a/src/nginxconfig/scss/_callout.scss
+++ b/src/nginxconfig/scss/_callout.scss
@@ -3,6 +3,7 @@
   border-radius: $border-radius;
   margin: 2rem .5rem 1rem;
   padding: 1.875rem 1.875rem 1.5rem;
+  transition: opacity $transition;
 
   &.floating {
     position: fixed;

--- a/src/nginxconfig/scss/_callout.scss
+++ b/src/nginxconfig/scss/_callout.scss
@@ -1,3 +1,29 @@
+/*
+Copyright 2021 DigitalOcean
+
+This code is licensed under the MIT License.
+You may obtain a copy of the License at
+https://github.com/digitalocean/nginxconfig.io/blob/master/LICENSE or https://mit-license.org/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
 .callout {
   background: $callout;
   border-radius: $border-radius;

--- a/src/nginxconfig/scss/style.scss
+++ b/src/nginxconfig/scss/style.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/templates/app.vue
+++ b/src/nginxconfig/templates/app.vue
@@ -112,6 +112,7 @@ THE SOFTWARE.
         </div>
 
         <Footer></Footer>
+        <ContributeCallout></ContributeCallout>
     </div>
 </template>
 
@@ -137,6 +138,7 @@ THE SOFTWARE.
     import Domain from './domain';
     import Global from './global';
     import DropletCallout from './callouts/droplet';
+    import ContributeCallout from './callouts/contribute';
     import Setup from './setup';
     import Footer from './footer';
 
@@ -151,6 +153,7 @@ THE SOFTWARE.
             Domain,
             Global,
             DropletCallout,
+            ContributeCallout,
             Setup,
             NginxPrism,
             YamlPrism: () => import('./prism/yaml'),

--- a/src/nginxconfig/templates/app.vue
+++ b/src/nginxconfig/templates/app.vue
@@ -87,6 +87,8 @@ THE SOFTWARE.
                     <h2>{{ $t('templates.app.globalConfig') }}</h2>
                     <Global :data="global"></Global>
 
+                    <DropletCallout></DropletCallout>
+
                     <h2>{{ $t('templates.app.setup') }}</h2>
                     <Setup :data="{ domains: domains.filter(d => d !== null), global, confFiles }"></Setup>
                 </div>
@@ -134,6 +136,7 @@ THE SOFTWARE.
 
     import Domain from './domain';
     import Global from './global';
+    import DropletCallout from './callouts/droplet';
     import Setup from './setup';
     import Footer from './footer';
 
@@ -147,6 +150,7 @@ THE SOFTWARE.
             Footer,
             Domain,
             Global,
+            DropletCallout,
             Setup,
             NginxPrism,
             YamlPrism: () => import('./prism/yaml'),

--- a/src/nginxconfig/templates/callouts/contribute.vue
+++ b/src/nginxconfig/templates/callouts/contribute.vue
@@ -1,4 +1,4 @@
-/*
+<!--
 Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
@@ -22,9 +22,26 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-*/
+-->
 
-import droplet from './droplet';
-import contribute from './contribute';
+<template>
+    <div class="callout floating">
+        <p>
+            {{ $t('templates.callouts.contribute.wantToContributeChanges') }}
+        </p>
+        <p>
+            <a href="https://github.com/digitalocean/nginxconfig.io"
+               class="button is-primary"
+               target="_blank"
+            >
+                {{ $t('templates.callouts.contribute.getInvolvedOnGitHub') }}
+            </a>
+        </p>
+    </div>
+</template>
 
-export default { droplet, contribute };
+<script>
+    export default {
+        name: 'ContributeCallout',
+    };
+</script>

--- a/src/nginxconfig/templates/callouts/contribute.vue
+++ b/src/nginxconfig/templates/callouts/contribute.vue
@@ -26,17 +26,20 @@ THE SOFTWARE.
 
 <template>
     <div class="callout floating" :style="style">
-        <p>
-            {{ $t('templates.callouts.contribute.wantToContributeChanges') }}
-        </p>
-        <p>
-            <a href="https://github.com/digitalocean/nginxconfig.io"
-               class="button is-primary"
-               target="_blank"
-            >
-                {{ $t('templates.callouts.contribute.getInvolvedOnGitHub') }}
+        <div class="close">
+            <p>
+                {{ $t('templates.callouts.contribute.wantToContributeChanges') }}
+            </p>
+            <a @click="close">
+                <i class="fas fa-times"></i>
             </a>
-        </p>
+        </div>
+        <a href="https://github.com/digitalocean/nginxconfig.io"
+           class="button is-primary"
+           target="_blank"
+        >
+            {{ $t('templates.callouts.contribute.getInvolvedOnGitHub') }}
+        </a>
     </div>
 </template>
 
@@ -45,12 +48,16 @@ THE SOFTWARE.
         name: 'ContributeCallout',
         data() {
             return {
-                visible: false,
+                scrolled: false,
+                closed: false,
             };
         },
         computed: {
+            visible() {
+                return this.$data.scrolled && !this.$data.closed;
+            },
             style() {
-                return this.$data.visible ? undefined : {
+                return this.visible ? undefined : {
                     opacity: 0,
                     pointerEvents: 'none',
                 };
@@ -58,10 +65,15 @@ THE SOFTWARE.
         },
         mounted() {
             document.addEventListener('scroll', () => {
-                if (this.$data.visible) return;
+                if (this.$data.scrolled) return;
                 if (window.scrollY < 300) return;
-                this.$data.visible = true;
+                this.$data.scrolled = true;
             });
+        },
+        methods: {
+            close() {
+                this.$data.closed = true;
+            },
         },
     };
 </script>

--- a/src/nginxconfig/templates/callouts/contribute.vue
+++ b/src/nginxconfig/templates/callouts/contribute.vue
@@ -25,7 +25,7 @@ THE SOFTWARE.
 -->
 
 <template>
-    <div class="callout floating">
+    <div class="callout floating" :style="style">
         <p>
             {{ $t('templates.callouts.contribute.wantToContributeChanges') }}
         </p>
@@ -43,5 +43,25 @@ THE SOFTWARE.
 <script>
     export default {
         name: 'ContributeCallout',
+        data() {
+            return {
+                visible: false,
+            };
+        },
+        computed: {
+            style() {
+                return this.$data.visible ? undefined : {
+                    opacity: 0,
+                    pointerEvents: 'none',
+                };
+            },
+        },
+        mounted() {
+            document.addEventListener('scroll', () => {
+                if (this.$data.visible) return;
+                if (window.scrollY < 300) return;
+                this.$data.visible = true;
+            });
+        },
     };
 </script>

--- a/src/nginxconfig/templates/callouts/contribute.vue
+++ b/src/nginxconfig/templates/callouts/contribute.vue
@@ -30,13 +30,14 @@ THE SOFTWARE.
             <p>
                 {{ $t('templates.callouts.contribute.wantToContributeChanges') }}
             </p>
-            <a @click="close">
+            <a @click.prevent="close">
                 <i class="fas fa-times"></i>
             </a>
         </div>
         <a href="https://github.com/digitalocean/nginxconfig.io"
            class="button is-primary"
            target="_blank"
+           @click="linkClickEvent"
         >
             {{ $t('templates.callouts.contribute.getInvolvedOnGitHub') }}
         </a>
@@ -44,6 +45,8 @@ THE SOFTWARE.
 </template>
 
 <script>
+    import analytics from '../../util/analytics';
+
     export default {
         name: 'ContributeCallout',
         data() {
@@ -68,11 +71,32 @@ THE SOFTWARE.
                 if (this.$data.scrolled) return;
                 if (window.scrollY < 300) return;
                 this.$data.scrolled = true;
+                this.calloutVisibleEvent();
             });
         },
         methods: {
             close() {
                 this.$data.closed = true;
+                this.closedEvent();
+            },
+            closedEvent() {
+                analytics({
+                    category: 'Contribute callout',
+                    action: 'Closed',
+                });
+            },
+            calloutVisibleEvent() {
+                analytics({
+                    category: 'Contribute callout',
+                    action: 'Visible',
+                    nonInteraction: true,
+                });
+            },
+            linkClickEvent() {
+                analytics({
+                    category: 'Contribute callout',
+                    action: 'Clicked',
+                });
             },
         },
     };

--- a/src/nginxconfig/templates/callouts/droplet.vue
+++ b/src/nginxconfig/templates/callouts/droplet.vue
@@ -1,5 +1,5 @@
-/*
-Copyright 2020 DigitalOcean
+<!--
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -22,35 +22,26 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-*/
+-->
 
-$header: #0071fe;
-$highlight: #f2c94c;
-$callout: #f3f5f9;
-@import "~do-bulma/src/style";
+<template>
+    <div class="callout">
+        <p>
+            {{ $t('templates.callouts.droplet.lookingForAPlaceToDeploy') }}
+            <ExternalLink :text="$t('templates.callouts.droplet.tryOutDigitalOceansDroplet')"
+                          link="https://marketplace.digitalocean.com/apps/lemp"
+            ></ExternalLink>
+        </p>
+    </div>
+</template>
 
-.do-bulma {
-  @import "../../../build/prism";
+<script>
+    import ExternalLink from 'do-vue/src/templates/external_link';
 
-  $pretty--color-dark: $primary;
-  $pretty--color-default: $primary;
-  @import "~pretty-checkbox/src/pretty-checkbox";
-
-  $vs-border-color: $border;
-  $vs-border-radius: $border-radius;
-  $vs-dropdown-box-shadow: 0 2px 4px rgba($dark-blue, .06);
-  $vs-state-active-bg: $primary;
-  @import "~vue-select/src/scss/vue-select";
-
-  @import "header";
-  @import "tabs";
-  @import "panel";
-  @import "fields";
-  @import "vue-select";
-  @import "modals";
-  @import "callout";
-  @import "setup";
-  @import "code";
-  @import "files";
-  @import "footer";
-}
+    export default {
+        name: 'DropletCallout',
+        components: {
+            ExternalLink,
+        },
+    };
+</script>

--- a/src/nginxconfig/templates/callouts/droplet.vue
+++ b/src/nginxconfig/templates/callouts/droplet.vue
@@ -30,6 +30,7 @@ THE SOFTWARE.
             {{ $t('templates.callouts.droplet.lookingForAPlaceToDeploy') }}
             <ExternalLink :text="$t('templates.callouts.droplet.tryOutDigitalOceansDroplet')"
                           link="https://marketplace.digitalocean.com/apps/lemp"
+                          @click.native="linkClickEvent"
             ></ExternalLink>
         </p>
     </div>
@@ -37,11 +38,30 @@ THE SOFTWARE.
 
 <script>
     import ExternalLink from 'do-vue/src/templates/external_link';
+    import analytics from '../../util/analytics';
 
     export default {
         name: 'DropletCallout',
         components: {
             ExternalLink,
+        },
+        mounted() {
+            this.calloutVisibleEvent();
+        },
+        methods: {
+            calloutVisibleEvent() {
+                analytics({
+                    category: 'Droplet callout',
+                    action: 'Visible',
+                    nonInteraction: true,
+                });
+            },
+            linkClickEvent() {
+                analytics({
+                    category: 'Droplet callout',
+                    action: 'Clicked',
+                });
+            },
         },
     };
 </script>

--- a/src/nginxconfig/util/analytics.js
+++ b/src/nginxconfig/util/analytics.js
@@ -27,8 +27,8 @@ THE SOFTWARE.
 export default ({ category, action, label, value, nonInteraction }) => {
     console.info('Analytics event:', { category, action, label, value, nonInteraction });
 
-    try {
-        // Google
+    /*try {
+        // Google Analytics
         window.ga('send', 'event', {
             eventCategory: category,
             eventAction: action,
@@ -38,11 +38,28 @@ export default ({ category, action, label, value, nonInteraction }) => {
         });
     } catch (_) {
         // If analytics fail, don't block anything else
+    }*/
+
+    try {
+        // Google Tag Manager
+        window.dataLayer = window.dataLayer || [];
+        window.dataLayer.push({
+            event: `${category} ${action}`,
+            category,
+            action,
+            label,
+            value,
+            nonInteraction,
+        });
+    } catch (_) {
+        // If analytics fail, don't block anything else
     }
 
     try {
         // Segment
-        window.analytics.track(`${category} ${action}`, {
+        window.analytics.track('Web Interaction', {
+            category,
+            action,
             label,
             value,
             nonInteraction,

--- a/src/nginxconfig/util/analytics.js
+++ b/src/nginxconfig/util/analytics.js
@@ -254,4 +254,36 @@ Category: 'Config files'
 Action: 'Code snippet copied'
 Label: name of file without nginx directory
 
+# Droplet callout is rendered
+
+File: callouts/droplet.vue
+Category: 'Droplet callout'
+Action: 'Visible'
+Non-interaction: true
+
+# User clicks on droplet callout
+
+File: callouts/droplet.vue
+Category: 'Droplet callout'
+Action: 'Clicked'
+
+# Contribute callout is rendered (on scroll)
+
+File: callouts/contribute.vue
+Category: 'Contribute callout'
+Action: 'Visible'
+Non-interaction: true
+
+# User clicks on contribute callout
+
+File: callouts/contribute.vue
+Category: 'Contribute callout'
+Action: 'Clicked'
+
+# User closes the contribute callout
+
+File: callouts/contribute.vue
+Category: 'Contribute callout'
+Action: 'Closed'
+
 */


### PR DESCRIPTION
## Type of Change

- **Tool Source:** App template, new callout templates, analytics, styling

## What issue does this relate to?

N/A

### What should this PR do?

Adds a callout between the global settings and setup sections to encourage folks to create a LEMP Droplet if they need somewhere to deploy their NGINX configuration.

Also adds a callout that floats bottom right on scroll, encouraging folks to contribute via GitHub to the tool if they are interested.

### What are the acceptance criteria?

- The visible analytics event for the Droplet callout fires as soon as the tool renders, flagged as a non-interaction event.
- When the user scrolls down a bit on the page, the Contribute callout appears and the analytics event for it being visible fires as a non-interaction event.
- As the user continues to scroll, the Contribute callout is sticky and stays attached to the viewport.
- Clicking on the link in the Droplet callout takes the user to the LEMP marketplace page in a new tab, firing the clicked analytics event.
- Clicking the button in the Contribute callout opens the nginxconfig GitHub repository in a new tab, firing the clicked analytics event.
- Clicking the close button on the Contribute callout closes it, firing the closed event. Scrolling around does NOT trigger it to reappear.