### PR TITLE
Improve Connection header for WebSocket reverse proxy

### DIFF
--- a/src/nginxconfig/generators/conf/general.conf.js
+++ b/src/nginxconfig/generators/conf/general.conf.js
@@ -124,6 +124,16 @@ export default (domains, global) => {
         config.brotli_types = gzipTypes;
     }
 
+    // Connection header for WebSocket reverse proxy
+    if (domains.some(d => d.reverseProxy.reverseProxy.computed)) {
+        config['# Connection header for WebSocket reverse proxy'] = '';
+        const map = 'map $http_upgrade $connection_upgrade';
+        config[map] = {
+            default: 'upgrade',
+            '""': 'close',
+        };
+    }
+
     // Done!
     return config;
 };

--- a/src/nginxconfig/generators/conf/general.conf.js
+++ b/src/nginxconfig/generators/conf/general.conf.js
@@ -124,16 +124,6 @@ export default (domains, global) => {
         config.brotli_types = gzipTypes;
     }
 
-    // Connection header for WebSocket reverse proxy
-    if (domains.some(d => d.reverseProxy.reverseProxy.computed)) {
-        config['# Connection header for WebSocket reverse proxy'] = '';
-        const map = 'map $http_upgrade $connection_upgrade';
-        config[map] = {
-            default: 'upgrade',
-            '""': 'close',
-        };
-    }
-
     // Done!
     return config;
 };

--- a/src/nginxconfig/generators/conf/nginx.conf.js
+++ b/src/nginxconfig/generators/conf/nginx.conf.js
@@ -190,6 +190,15 @@ export default (domains, global) => {
         }
     }
 
+    // Connection header for WebSocket reverse proxy
+    if (domains.some(d => d.reverseProxy.reverseProxy.computed)) {
+        config.http.push(['# Connection header for WebSocket reverse proxy', '']);
+        config.http.push(['map $http_upgrade $connection_upgrade', {
+            'default': 'upgrade',
+            '""': 'close',
+        }]);
+    }
+
     // Configs!
     config.http.push(['# Load configs', '']);
     config.http.push(['include', [

--- a/src/nginxconfig/generators/conf/proxy.conf.js
+++ b/src/nginxconfig/generators/conf/proxy.conf.js
@@ -32,7 +32,7 @@ export default global => {
 
     config['# Proxy headers'] = '';
     config['proxy_set_header Upgrade'] = '$http_upgrade';
-    config['proxy_set_header Connection'] = '"upgrade"';
+    config['proxy_set_header Connection'] = '$connection_upgrade';
     config['proxy_set_header Host'] = '$host';
     config['proxy_set_header X-Real-IP'] = '$remote_addr';
     config['proxy_set_header X-Forwarded-For'] = '$proxy_add_x_forwarded_for';


### PR DESCRIPTION
## Type of Change
- **Tool Source:** Config generator (general.conf.js, proxy.conf.js)

## What issue does this relate to?
Reverse Proxy always sends `Connection: upgrade` header.

### What should this PR do?
- add nginx `map` to general.conf
- use map variable in proxy.conf

With this change nginx will only forward `Connection: upgrade` when the client sets `Upgrade`.
As far as I am aware this is a cleaner way of forwarding the `Connection` and `Upgrade` headers.  

Reference: https://nginx.org/en/docs/http/websocket.html

### What are the acceptance criteria?
- [ ] Double check if my understanding of the upgrade mechanism is correct.
  - https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism
  - https://tools.ietf.org/html/rfc7230#section-6.1
- [x] The highlight feature also highlights the line above the added config. Not sure why.
