### PR TITLE
Support custom PHP server values

### DIFF
--- a/src/nginxconfig/generators/conf/nginx.conf.js
+++ b/src/nginxconfig/generators/conf/nginx.conf.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -27,6 +27,7 @@ THE SOFTWARE.
 import sslProfiles from '../../util/ssl_profiles';
 import websiteConf from './website.conf';
 import shareQuery from '../../util/share_query';
+import phpPath from '../../util/php_path';
 
 export default (domains, global) => {
     const config = {};
@@ -53,8 +54,8 @@ export default (domains, global) => {
     if (global.php.phpBackupServer.computed)
         config.http.push(['upstream php', {
             server: [
-                `${global.php.phpServer.computed[0] === '/' ? 'unix:' : ''}${global.php.phpServer.computed}`,
-                `${global.php.phpBackupServer.computed[0] === '/' ? 'unix:' : ''}${global.php.phpBackupServer.computed} backup`,
+                phpPath(global),
+                `${phpPath(global, true)} backup`,
             ],
         }]);
 

--- a/src/nginxconfig/i18n/en/templates/global_sections/php.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -40,5 +40,6 @@ export default {
     php74Socket: '7.4 socket',
     php80Socket: '8.0 socket',
     phpSocket: 'PHP socket',
+    custom: 'Custom',
     disabled: 'Disabled',
 };

--- a/src/nginxconfig/i18n/fr/templates/global_sections/php.js
+++ b/src/nginxconfig/i18n/fr/templates/global_sections/php.js
@@ -40,5 +40,6 @@ export default {
     php74Socket: 'Socket 7.4',
     php80Socket: 'Socket 8.0',
     phpSocket: 'Socket PHP',
+    custom: 'Custom', // TODO: translate
     disabled: 'Désactivé',
 };

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/php.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -40,5 +40,6 @@ export default {
     php74Socket: 'Socket 7.4',
     php80Socket: 'Socket 8.0',
     phpSocket: 'Socket PHP',
+    custom: 'Custom', // TODO: translate
     disabled: 'Desabilitado',
 };

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/php.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -40,5 +40,6 @@ export default {
     php74Socket: '7.4 socket',
     php80Socket: '8.0 socket',
     phpSocket: 'PHP socket',
+    custom: 'Custom', // TODO: translate
     disabled: '禁用',
 };

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/php.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -40,5 +40,6 @@ export default {
     php74Socket: '7.4 socket',
     php80Socket: '8.0 socket',
     phpSocket: 'PHP socket',
+    custom: 'Custom', // TODO: translate
     disabled: '禁用',
 };

--- a/src/nginxconfig/templates/global_sections/php.vue
+++ b/src/nginxconfig/templates/global_sections/php.vue
@@ -112,6 +112,7 @@ THE SOFTWARE.
         '/var/run/php/php-fpm.sock': 'templates.globalSections.php.phpSocket',
         'custom': 'templates.globalSections.php.custom',
     };
+    const hiddenValues = ['', 'custom'];
 
     const defaults = {
         phpServer: {
@@ -149,11 +150,11 @@ THE SOFTWARE.
             ...computedFromDefaults(defaults, 'php'),   // Getters & setters for the delegated data
             phpServerOptions() {
                 return Object.entries(this.$props.data.phpServer.options)
-                    .map(([key, value]) => ({ label: `${this.$t(value)}${key ? `: ${key}` : ''}`, value: key }));
+                    .map(([key, value]) => this.formattedOption(key, value));
             },
             phpBackupServerOptions() {
                 return Object.entries(this.$props.data.phpBackupServer.options)
-                    .map(([key, value]) => ({ label: `${this.$t(value)}${key ? `: ${key}` : ''}`, value: key }));
+                    .map(([key, value]) => this.formattedOption(key, value));
             },
         },
         watch: {
@@ -212,11 +213,23 @@ THE SOFTWARE.
                 },
                 deep: true,
             },
-            // Ensure 'Disabled' gets translated in VueSelect on language switch
+            // Ensure 'Custom'/'Disabled' get translated in VueSelect on language switch
             '$i18n.locale'() {
-                const updated = this.phpBackupServerOptions
+                const updated = this.phpServerOptions
+                    .find(x => x.value === this.$refs.phpServerOptions.$data._value.value);
+                if (updated) this.$refs.phpServerOptions.$data._value = updated;
+
+                const updatedBackup = this.phpBackupServerOptions
                     .find(x => x.value === this.$refs.phpBackupServerSelect.$data._value.value);
-                if (updated) this.$refs.phpBackupServerSelect.$data._value = updated;
+                if (updatedBackup) this.$refs.phpBackupServerSelect.$data._value = updatedBackup;
+            },
+        },
+        methods: {
+            formattedOption(key, value) {
+                return {
+                    label: `${this.$t(value)}${hiddenValues.includes(key) ? '' : `: ${key}`}`,
+                    value: key,
+                };
             },
         },
     };

--- a/src/nginxconfig/templates/global_sections/php.vue
+++ b/src/nginxconfig/templates/global_sections/php.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -42,8 +42,8 @@ THE SOFTWARE.
         </div>
 
         <template v-else>
-            <div class="field is-horizontal">
-                <div class="field-label">
+            <div class="field is-horizontal is-aligned-top">
+                <div class="field-label has-margin-top">
                     <label class="label">{{ $t('templates.globalSections.php.phpServer') }}</label>
                 </div>
                 <div class="field-body">
@@ -55,12 +55,18 @@ THE SOFTWARE.
                                        :reduce="s => s.value"
                             ></VueSelect>
                         </div>
+
+                        <div v-if="phpServerCustomEnabled"
+                             :class="`control${phpServerCustomChanged ? ' is-changed' : ''}`"
+                        >
+                            <input v-model="phpServerCustom" class="input" type="text" :placeholder="$props.data.phpServerCustom.default" />
+                        </div>
                     </div>
                 </div>
             </div>
 
-            <div class="field is-horizontal">
-                <div class="field-label">
+            <div class="field is-horizontal is-aligned-top">
+                <div class="field-label has-margin-top">
                     <label class="label">{{ $t('templates.globalSections.php.phpBackupServer') }}</label>
                 </div>
                 <div class="field-body">
@@ -72,6 +78,12 @@ THE SOFTWARE.
                                        :clearable="false"
                                        :reduce="s => s.value"
                             ></VueSelect>
+                        </div>
+
+                        <div v-if="phpBackupServerCustomEnabled"
+                             :class="`control${phpBackupServerCustomChanged ? ' is-changed' : ''}`"
+                        >
+                            <input v-model="phpBackupServerCustom" class="input" type="text" :placeholder="$props.data.phpBackupServerCustom.default" />
                         </div>
                     </div>
                 </div>
@@ -98,6 +110,7 @@ THE SOFTWARE.
         '/var/run/php/php7.4-fpm.sock': 'templates.globalSections.php.php74Socket',
         '/var/run/php/php8.0-fpm.sock': 'templates.globalSections.php.php80Socket',
         '/var/run/php/php-fpm.sock': 'templates.globalSections.php.phpSocket',
+        'custom': 'templates.globalSections.php.custom',
     };
 
     const defaults = {
@@ -106,10 +119,18 @@ THE SOFTWARE.
             options: serverOptions,
             enabled: true,
         },
+        phpServerCustom: {
+            default: 'unix:/var/run/php/php-fpm.sock',
+            enabled: false,
+        },
         phpBackupServer: {
             default: '',
             options: { '': 'templates.globalSections.php.disabled', ...serverOptions },
             enabled: true,
+        },
+        phpBackupServerCustom: {
+            default: 'unix:/var/run/php/php-fpm.sock',
+            enabled: false,
         },
     };
 
@@ -139,20 +160,36 @@ THE SOFTWARE.
             // Check server selection is valid
             '$props.data.phpServer': {
                 handler(data) {
-                    // This might cause recursion, but seems not to
-                    if (data.enabled)
+                    if (data.enabled) {
+                        // This might cause recursion, but seems not to
                         if (!Object.keys(data.options).includes(data.computed))
                             data.computed = data.default;
+
+                        // Show the custom box
+                        this.$props.data.phpServerCustom.enabled = data.computed === 'custom';
+                        return;
+                    }
+
+                    // Hide custom if disabled
+                    this.$props.data.phpServerCustom.enabled = false;
                 },
                 deep: true,
             },
             // Check backup server selection is valid
             '$props.data.phpBackupServer': {
                 handler(data) {
-                    // This might cause recursion, but seems not to
-                    if (data.enabled)
+                    if (data.enabled) {
+                        // This might cause recursion, but seems not to
                         if (!Object.keys(data.options).includes(data.computed))
                             data.computed = data.default;
+
+                        // Show the custom box
+                        this.$props.data.phpBackupServerCustom.enabled = data.computed === 'custom';
+                        return;
+                    }
+
+                    // Hide custom if disabled
+                    this.$props.data.phpBackupServerCustom.enabled = false;
                 },
                 deep: true,
             },

--- a/src/nginxconfig/util/php_path.js
+++ b/src/nginxconfig/util/php_path.js
@@ -24,37 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import phpPath from '../../util/php_path';
-
-export default (domains, global) => {
-    const legacyRouting = domains.some(d => d.routing.legacyPhpRouting.computed);
-    const config = {};
-
-    if (legacyRouting) {
-        config['# split path'] = '';
-        config.fastcgi_split_path_info = '^(.+\\.php)(/.+)$';
-        config.set = '$_fastcgi_path_info $fastcgi_path_info';
-    }
-
-    config['# 404'] = '';
-    config.try_files = '$fastcgi_script_name =404';
-
-    config['# default fastcgi_params'] = '';
-    config.include = 'fastcgi_params';
-
-    config['# fastcgi settings'] = '';
-    config.fastcgi_pass = domains.some(d => d.php.php.computed) && global.php.phpBackupServer.computed !== ''
-        ? 'php' : phpPath(global);
-    config.fastcgi_index = 'index.php';
-    config.fastcgi_buffers = '8 16k';
-    config.fastcgi_buffer_size = '32k';
-
-    config['# fastcgi params'] = '';
-    config['fastcgi_param DOCUMENT_ROOT'] = '$realpath_root';
-    config['fastcgi_param SCRIPT_FILENAME'] = '$realpath_root$fastcgi_script_name';
-    if (legacyRouting) config['fastcgi_param PATH_INFO'] = '$_fastcgi_path_info';
-    config['fastcgi_param PHP_ADMIN_VALUE'] = '"open_basedir=$base/:/usr/lib/php/:/tmp/"';
-
-    // Done!
-    return config;
+export default (global, backup = false) => {
+    const key = `php${backup ? 'Backup' : ''}Server`;
+    if (global.php[key].computed === 'custom') return global.php[`${key}Custom`].computed;
+    return (global.php[key].computed[0] === '/' ? 'unix:' : '') + global.php[key].computed;
 };


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Global PHP template, nginx & fastcgi conf generators

## What issue does this relate to?

Resolves #212

### What should this PR do?

Adds a custom option to the PHP server and PHP backup server options in the Global settings of the tool.

### What are the acceptance criteria?

- If custom setting is used, the text box shows up and the value is used in the nginx configuration.
- Custom setting is preserved in the URL, and if the page is reloaded the state is restored correctly.