### PR TITLE
Allow setting of custom sizes for types hash

### DIFF
--- a/src/nginxconfig/generators/conf/nginx.conf.js
+++ b/src/nginxconfig/generators/conf/nginx.conf.js
@@ -66,7 +66,8 @@ export default (domains, global) => {
         config.http.push(['server_tokens', 'off']);
     if (!global.logging.logNotFound.computed)
         config.http.push(['log_not_found', 'off']);
-    config.http.push(['types_hash_max_size', 2048]);
+    config.http.push(['types_hash_max_size', global.nginx.typesHashMaxSize.computed]);
+    config.http.push(['types_hash_bucket_size', global.nginx.typesHashBucketSize.computed]);
     config.http.push(['client_max_body_size', `${global.nginx.clientMaxBodySize.computed}M`]);
 
     config.http.push(['# MIME', '']);

--- a/src/nginxconfig/templates/global_sections/nginx.vue
+++ b/src/nginxconfig/templates/global_sections/nginx.vue
@@ -116,6 +116,38 @@ THE SOFTWARE.
                 </div>
             </div>
         </div>
+
+        <div class="field is-horizontal">
+            <div class="field-label">
+                <label class="label">types_hash_max_size</label>
+            </div>
+            <div class="field-body">
+                <div class="field">
+                    <div :class="`control${typesHashMaxSizeChanged ? ' is-changed' : ''}`">
+                        <VueSelect v-model="typesHashMaxSize"
+                                   :options="$props.data.typesHashMaxSize.options"
+                                   :clearable="false"
+                        ></VueSelect>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="field is-horizontal">
+            <div class="field-label">
+                <label class="label">types_hash_bucket_size</label>
+            </div>
+            <div class="field-body">
+                <div class="field">
+                    <div :class="`control${typesHashBucketSizeChanged ? ' is-changed' : ''}`">
+                        <VueSelect v-model="typesHashBucketSize"
+                                   :options="$props.data.typesHashBucketSize.options"
+                                   :clearable="false"
+                        ></VueSelect>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </template>
 
@@ -148,6 +180,16 @@ THE SOFTWARE.
         },
         clientMaxBodySize: {
             default: 16,
+            enabled: true,
+        },
+        typesHashMaxSize: {
+            default: 2048,
+            options: Array.from({ length: 8 }, (_, i) => Math.pow(2, i + 6)),
+            enabled: true,
+        },
+        typesHashBucketSize: {
+            default: 64,
+            options: Array.from({ length: 10 }, (_, i) => Math.pow(2, i + 4)),
             enabled: true,
         },
     };
@@ -192,6 +234,26 @@ THE SOFTWARE.
                     if (data.enabled)
                         if (data.computed < 0)
                             data.computed = 0;
+                },
+                deep: true,
+            },
+            // Check hash max size selection is valid
+            '$props.data.typesHashMaxSize': {
+                handler(data) {
+                    // This might cause recursion, but seems not to
+                    if (data.enabled)
+                        if (!data.options.includes(data.computed))
+                            data.computed = data.default;
+                },
+                deep: true,
+            },
+            // Check hash bucket size selection is valid
+            '$props.data.typesHashBucketSize': {
+                handler(data) {
+                    // This might cause recursion, but seems not to
+                    if (data.enabled)
+                        if (!data.options.includes(data.computed))
+                            data.computed = data.default;
                 },
                 deep: true,
             },


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Nginx conf, nginx global settings

## What issue does this relate to?

Resolves #213

### What should this PR do?

Adds two dropdown settings under the NGINX global settings for the types hash size directives.

### What are the acceptance criteria?

- The default value for the `types_hash_max_size` directive is 2048, as it was before
- The default value for `types_hash_bucket_size` is 64, matching the [documented default](http://nginx.org/en/docs/http/ngx_http_core_module.html#types_hash_bucket_size)
- Changing either value is reflected in the configuration
- Changing either value is reflected in the saved query params