### PR TITLE
Fix typo on Configure Step

### DIFF
--- a/src/nginxconfig/templates/setup_sections/certbot.vue
+++ b/src/nginxconfig/templates/setup_sections/certbot.vue
@@ -85,7 +85,7 @@ THE SOFTWARE.
                     {{ $t('templates.setupSections.certbot.configureCertbotToReloadNginxOnCertificateRenewal') }}
                     <br />
                 </p>
-                <BashPrism cmd="echo -e '#!/bin/bash\nnginx -t && systemctl reload nginx' | sudo tee /etc/letsencrypt/renewal-hooks/post/nginx-reload.sh"
+                <BashPrism cmd="echo -e '#!/bin/bash\nginx -t && systemctl reload nginx' | sudo tee /etc/letsencrypt/renewal-hooks/post/nginx-reload.sh"
                            @copied="codeCopiedEvent('Create nginx auto-restart on renewal')"
                 ></BashPrism>
                 <BashPrism cmd="sudo chmod a+x /etc/letsencrypt/renewal-hooks/post/nginx-reload.sh"


### PR DESCRIPTION
fix a typo on the "Configure Certbot to reload NGINX when it successfully renews certificates:" step

## Type of Change
- **Something else:** Fix a typo on the configuration step of certbot

## What issue does this relate to?

None

### What should this PR do?

Update the 6th step command on the certbot section

### What are the acceptance criteria?

Someone more experience should make sure that in efect the correct command is #!/bin/bash\nginx and not #!/bin/bash\ **n**nginx 