### PR TITLE
Prevent access error in phpServerOptions

### DIFF
--- a/src/nginxconfig/templates/global_sections/php.vue
+++ b/src/nginxconfig/templates/global_sections/php.vue
@@ -216,7 +216,7 @@ THE SOFTWARE.
             // Ensure 'Custom'/'Disabled' get translated in VueSelect on language switch
             '$i18n.locale'() {
                 if (!this.$refs.phpServerOptions)
-                    return false
+                    return false;
                 const updated = this.phpServerOptions
                     .find(x => x.value === this.$refs.phpServerOptions.$data._value.value);
                 if (updated) this.$refs.phpServerOptions.$data._value = updated;

--- a/src/nginxconfig/templates/global_sections/php.vue
+++ b/src/nginxconfig/templates/global_sections/php.vue
@@ -215,6 +215,8 @@ THE SOFTWARE.
             },
             // Ensure 'Custom'/'Disabled' get translated in VueSelect on language switch
             '$i18n.locale'() {
+                if (!this.$refs.phpServerOptions)
+                    return false
                 const updated = this.phpServerOptions
                     .find(x => x.value === this.$refs.phpServerOptions.$data._value.value);
                 if (updated) this.$refs.phpServerOptions.$data._value = updated;


### PR DESCRIPTION
## Type of Change
- **Something else:**   Fix a undefined access for  phpServerOptions 

## What issue does this relate to?
None

### What should this PR do?
Prevent undefined access for computed var (phpServerOptions)
### What are the acceptance criteria?
No breaking changes
