### PR TITLE
Send a consistent event name to GTM

### DIFF
--- a/src/nginxconfig/util/analytics.js
+++ b/src/nginxconfig/util/analytics.js
@@ -44,7 +44,7 @@ export default ({ category, action, label, value, nonInteraction }) => {
         // Google Tag Manager
         window.dataLayer = window.dataLayer || [];
         window.dataLayer.push({
-            event: `${category} ${action}`,
+            event: 'nginx_tool',
             category,
             action,
             label,


### PR DESCRIPTION
## Type of Change

- **Tool Source:** analytics js util

## What issue does this relate to?

N/A

### What should this PR do?

Set a consistent event name for when we push events to the GTM data layer.

### What are the acceptance criteria?

In local dev, you should now see events being sent to GA correctly, as GTM is detecting the new event name as passing the data layer pushes to GA.