### PR TITLE
Disable index.html fallback in dev

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -34,6 +34,9 @@ module.exports = {
     outputDir: 'dist',
     filenameHashing: false, // Don't hash the output, so we can embed on the DigitalOcean Community
     productionSourceMap: false,
+    devServer: {
+        historyApiFallback: false, // Don't serve index.html for 404s in dev
+    },
     configureWebpack: {
         node: false, // Disable Node.js polyfills (Buffer etc.) -- This will be default in Webpack 5
         plugins: [


### PR DESCRIPTION
## Type of Change

- **Build Scripts:** Vue CLI config

## What issue does this relate to?

N/A

### What should this PR do?

Over the last few days working on the tool, I noticed (as did @powerdot) that the tool sometimes injects itself twice (via a call to /community/banner). This is due to the underlying webpack dev server responding to 404s with fallback to index.html (for SPA support). We don't need this, and it is causing issues, so this disables the fallback routing in dev.

### What are the acceptance criteria?

- In dev, the tool does not inject itself twice
- In dev, the network call to /community/banner 404s