### PR TITLE
Tweak sed commands in certbot setup

### DIFF
--- a/src/nginxconfig/templates/setup_sections/certbot.vue
+++ b/src/nginxconfig/templates/setup_sections/certbot.vue
@@ -33,7 +33,7 @@ THE SOFTWARE.
                     <br />
                 </p>
                 <BashPrism :key="sitesAvailable"
-                           :cmd="`sed -i -r 's/(listen .*443)/\\1;#/g; s/(ssl_(certificate|certificate_key|trusted_certificate) )/#;#\\1/g' ${sitesAvailable}`"
+                           :cmd="`sed -i -r 's/(listen .*443)/\\1; #/g; s/(ssl_(certificate|certificate_key|trusted_certificate) )/#;#\\1/g; s/(server \\{)/\\1\\n    ssl off;/g' ${sitesAvailable}`"
                            @copied="codeCopiedEvent('Disable ssl directives')"
                 ></BashPrism>
             </li>
@@ -65,7 +65,7 @@ THE SOFTWARE.
                     <br />
                 </p>
                 <BashPrism :key="sitesAvailable"
-                           :cmd="`sed -i -r 's/#?;#//g' ${sitesAvailable}`"
+                           :cmd="`sed -i -r -z 's/#?; ?#//g; s/(server \\{)\\n    ssl off;/\\1/g' ${sitesAvailable}`"
                            @copied="codeCopiedEvent('Enable ssl directives')"
                 ></BashPrism>
             </li>


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue: Certbot setup

## What issue does this relate to?

Resolves #215

### What should this PR do?

Update the sed commands used during the certbot setup to hopefully avoid the nginx error issue in #215

### What are the acceptance criteria?

Certbot can be configured following the instructions with nginx emitting any errors (it will emit warnings for the `ssl` directive, but this is to be expected).