### PR TITLE
Fix broken WordPress comment form by removing the necessary PHP script from the deny pattern

### DIFF
--- a/src/nginxconfig/generators/conf/wordpress.conf.js
+++ b/src/nginxconfig/generators/conf/wordpress.conf.js
@@ -51,7 +51,7 @@ export default global => {
     };
 
     config['# WordPress: deny general stuff'] = '';
-    config['location ~* ^/(?:xmlrpc\\.php|wp-links-opml\\.php|wp-config\\.php|wp-config-sample\\.php|wp-comments-post\\.php|readme\\.html|license\\.txt)$'] = {
+    config['location ~* ^/(?:xmlrpc\\.php|wp-links-opml\\.php|wp-config\\.php|wp-config-sample\\.php|readme\\.html|license\\.txt)$'] = {
         deny: 'all',
     };
 


### PR DESCRIPTION
## Type of Change

Bugfix

### What should this PR do?

This fix would allow the `wp-comments-post.php` being used to post a new comment. If this script is blocked, commenting on a WordPress website is no longer possible.