### PR TITLE
Rely on Prism being in window to fix dev error

### DIFF
--- a/src/nginxconfig/templates/prism/bash.vue
+++ b/src/nginxconfig/templates/prism/bash.vue
@@ -31,8 +31,6 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import Prism from 'prismjs';
-
     export default {
         name: 'BashPrism',
         props: {
@@ -40,7 +38,7 @@ THE SOFTWARE.
         },
         mounted() {
             console.info(`Highlighting ${this.$props.cmd}...`);
-            Prism.highlightAllUnder(this.$el);
+            window.Prism.highlightAllUnder(this.$el);
         },
         methods: {
             copied(event) {

--- a/src/nginxconfig/templates/prism/docker.vue
+++ b/src/nginxconfig/templates/prism/docker.vue
@@ -32,7 +32,6 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import Prism from 'prismjs';
     import 'prismjs/components/prism-docker';
 
     export default {
@@ -44,7 +43,7 @@ THE SOFTWARE.
         },
         mounted() {
             console.info(`Highlighting ${this.$props.name}...`);
-            Prism.highlightAllUnder(this.$el);
+            window.Prism.highlightAllUnder(this.$el);
         },
         methods: {
             copied(event) {

--- a/src/nginxconfig/templates/prism/nginx.vue
+++ b/src/nginxconfig/templates/prism/nginx.vue
@@ -32,8 +32,6 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import Prism from 'prismjs';
-
     export default {
         name: 'NginxPrism',
         props: {
@@ -43,7 +41,7 @@ THE SOFTWARE.
         },
         mounted() {
             console.info(`Highlighting ${this.$props.name}...`);
-            Prism.highlightAllUnder(this.$el);
+            window.Prism.highlightAllUnder(this.$el);
         },
         methods: {
             copied(event) {

--- a/src/nginxconfig/templates/prism/yaml.vue
+++ b/src/nginxconfig/templates/prism/yaml.vue
@@ -32,7 +32,6 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import Prism from 'prismjs';
     import 'prismjs/components/prism-yaml';
 
     export default {
@@ -44,7 +43,7 @@ THE SOFTWARE.
         },
         mounted() {
             console.info(`Highlighting ${this.$props.name}...`);
-            Prism.highlightAllUnder(this.$el);
+            window.Prism.highlightAllUnder(this.$el);
         },
         methods: {
             copied(event) {


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Prism vue templates

## What issue does this relate to?

Resolves #235

### What should this PR do?

Removes the repeated imports of Prism which seem to be causing issues in dev only. Prism does some funky stuff relying on binding to window or the global scope, which seems to be breaking in dev.

Decided that instead of digging any deeper to fix this, I just removed the duplicate imports and rely on the window bind in provides, which works and gets rid of the error.

### What are the acceptance criteria?

Prism works in dev, does not error when you change settings.

Prism works in built version, does not error when you change settings.