### PR TITLE
Assorted cleanup + fixes

### DIFF
--- a/src/nginxconfig/generators/conf/nginx.conf.js
+++ b/src/nginxconfig/generators/conf/nginx.conf.js
@@ -42,14 +42,16 @@ export default (domains, global) => {
         config.pid = global.nginx.pid.computed;
     config.worker_processes = global.nginx.workerProcesses.computed;
     config.worker_rlimit_nofile = 65535;
+
+    // Modules
+    config['# Load modules'] = '';
+    config.include = `${global.nginx.nginxConfigDirectory.computed.replace(/\/+$/, '')}/modules-enabled/*.conf`;
+
+    // Events
     config.events = {
         multi_accept: 'on',
         worker_connections: 65535,
     };
-
-    // Modules!
-    config['# Load modules'] = '';
-    config.include = `${global.nginx.nginxConfigDirectory.computed.replace(/\/+$/, '')}/modules-enabled/*`;
 
     // HTTP (kv so we can use the same key multiple times)
     config.http = [];

--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -60,14 +60,13 @@ const httpsListen = domain => {
     const config = [];
 
     // HTTPS
-    config.push(['listen', `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}443 ssl${domain.https.http2.computed ? ' http2' : ''}`]);
+    config.push(['listen',
+        `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}443 ssl${domain.https.http2.computed ? ' http2' : ''}`]);
 
     // HTTP/3
     if (domain.https.http3.computed)
         config.push(['listen',
-            `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}443 http3` 
-            + `${domain.https.portReuse.computed ? ' reuseport' : ''}`,
-        ]);
+            `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}443 http3${domain.https.portReuse.computed ? ' reuseport' : ''}`]);
 
     // v6
     if (domain.server.listenIpv6.computed)
@@ -77,8 +76,8 @@ const httpsListen = domain => {
     // v6 HTTP/3
     if (domain.server.listenIpv6.computed && domain.https.http3.computed)
         config.push(['listen',
-            `[${domain.server.listenIpv6.computed}]:443 http3${domain.https.portReuse.computed ? ' reuseport' : ''}`,
-        ]);
+            `[${domain.server.listenIpv6.computed}]:443 http3${domain.https.portReuse.computed ? ' reuseport' : ''}`]);
+
     return config;
 };
 
@@ -86,7 +85,8 @@ const httpListen = domain => {
     const config = [];
 
     // Not HTTPS
-    config.push(['listen', `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}80`]);
+    config.push(['listen',
+        `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}80`]);
 
     // v6
     if (domain.server.listenIpv6.computed)
@@ -204,7 +204,8 @@ export default (domain, domains, global) => {
         serverConfig.push(['# logging', '']);
 
         if (domain.logging.accessLog.computed)
-            serverConfig.push(['access_log', getAccessLogDomainPath(domain, global) + (global.logging.cloudflare.computed ? ' cloudflare' : '')]);
+            serverConfig.push(['access_log',
+                getAccessLogDomainPath(domain, global) + (global.logging.cloudflare.computed ? ' cloudflare' : '')]);
 
         if (domain.logging.errorLog.computed)
             serverConfig.push(['error_log', getErrorLogDomainPath(domain, global)]);
@@ -383,12 +384,14 @@ export default (domain, domains, global) => {
         const redirectConfig = [];
 
         redirectConfig.push(...listenConfig(domain));
-        redirectConfig.push(['server_name', `${domain.server.wwwSubdomain.computed ? '' : '*'}.${domain.server.domain.computed}`]);
+        redirectConfig.push(['server_name',
+            `${domain.server.wwwSubdomain.computed ? '' : '*'}.${domain.server.domain.computed}`]);
 
         // HTTPS
         redirectConfig.push(...sslConfig(domain, global));
 
-        redirectConfig.push(['return', `301 http${domain.https.https.computed ? 's' : ''}://${domain.server.wwwSubdomain.computed ? 'www.' : ''}${domain.server.domain.computed}$request_uri`]);
+        redirectConfig.push(['return',
+            `301 http${domain.https.https.computed ? 's' : ''}://${domain.server.wwwSubdomain.computed ? 'www.' : ''}${domain.server.domain.computed}$request_uri`]);
 
         // Add the redirect config to the parent config now its built
         config.push([`# ${domain.server.wwwSubdomain.computed ? 'non-www, ' : ''}subdomains redirect`, '']);
@@ -400,7 +403,8 @@ export default (domain, domains, global) => {
         // Add the redirect config to the parent config now its built
         config.push(['# HTTP redirect', '']);
         if (domain.server.wwwSubdomain.computed && !domain.server.redirectSubdomains.computed) {
-            config.push(['server', httpRedirectConfig(domain, global, domain.server.domain.computed, `www.${domain.server.domain.computed}`)]);
+            config.push(['server', httpRedirectConfig(domain, global, domain.server.domain.computed,
+                `www.${domain.server.domain.computed}`)]);
             config.push(['server', httpRedirectConfig(domain, global, `www.${domain.server.domain.computed}`)]);
         } else if (!domain.server.wwwSubdomain.computed && !domain.server.redirectSubdomains.computed) {
             config.push(['server', httpRedirectConfig(domain, global, domain.server.domain.computed)]);
@@ -409,7 +413,8 @@ export default (domain, domains, global) => {
             config.push(['server', httpRedirectConfig(domain, global, `cdn.${domain.server.domain.computed}`)]);
         }
         if (domain.server.redirectSubdomains.computed) {
-            config.push(['server', httpRedirectConfig(domain, global, `.${domain.server.domain.computed}`, `${domain.server.wwwSubdomain.computed ? 'www.' : '' }${domain.server.domain.computed}`)]);
+            config.push(['server', httpRedirectConfig(domain, global, `.${domain.server.domain.computed}`,
+                `${domain.server.wwwSubdomain.computed ? 'www.' : '' }${domain.server.domain.computed}`)]);
         }
     }
 

--- a/src/nginxconfig/i18n/en/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/en/templates/domain_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/en/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/en/templates/domain_sections/https.js
@@ -42,4 +42,9 @@ export default {
     certificationType: 'Certification type',
     customCertificate: 'Custom certificate',
     letsEncryptEmail: `${common.letsEncrypt} email`,
+    http3Warning1: 'HTTP/3 isn\'t a standard NGINX module, check the ',
+    http3Warning2: 'NGINX QUIC readme ',
+    http3Warning3: ' or the ',
+    http3Warning4: 'Cloudflare quiche project ',
+    http3Warning5: ' for how to build NGINX with HTTP/3!',
 };

--- a/src/nginxconfig/i18n/en/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/https.js
@@ -47,9 +47,4 @@ export default {
     ipv4Only: `${ipv4} only`,
     ipv6Only: `${ipv6} only`,
     ipv4AndIpv6: `${ipv4} & ${ipv6}`,
-    http3Warning1: 'HTTP/3 isn\'t a standard NGINX module, check the ',
-    http3Warning2: 'NGINX QUIC readme ',
-    http3Warning3: ' or the ',
-    http3Warning4: 'Cloudflare quiche project ',
-    http3Warning5: ' for how to build NGINX with HTTP/3!',
 };

--- a/src/nginxconfig/i18n/fr/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/fr/templates/domain_sections/https.js
@@ -42,4 +42,9 @@ export default {
     certificationType: 'Type de certification',
     customCertificate: 'Certificat personnalisé',
     letsEncryptEmail: `E-mail ${common.letsEncrypt}`,
+    http3Warning1: 'HTTP/3 isn\'t a standard NGINX module, check the ', // TODO: translate
+    http3Warning2: 'NGINX QUIC readme ', // TODO: translate
+    http3Warning3: ' or the ', // TODO: translate
+    http3Warning4: 'Cloudflare quiche project ', // TODO: translate
+    http3Warning5: ' for how to build NGINX with HTTP/3!', // TODO: translate
 };

--- a/src/nginxconfig/i18n/fr/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/fr/templates/global_sections/https.js
@@ -47,9 +47,4 @@ export default {
     ipv4Only: `${ipv4} seulement`,
     ipv6Only: `${ipv6} seulement`,
     ipv4AndIpv6: `${ipv4} & ${ipv6}`,
-    http3Warning1: 'HTTP/3 isn\'t a standard NGINX module, check the ', // TODO: translate 
-    http3Warning2: 'NGINX QUIC readme ', // TODO: translate 
-    http3Warning3: ' or the ', // TODO: translate 
-    http3Warning4: 'Cloudflare quiche project ', // TODO: translate 
-    http3Warning5: ' for how to build NGINX with HTTP/3!', // TODO: translate 
 };

--- a/src/nginxconfig/i18n/pt-br/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/pt-br/templates/domain_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/pt-br/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/pt-br/templates/domain_sections/https.js
@@ -42,4 +42,9 @@ export default {
     certificationType: 'Tipo de certificação',
     customCertificate: 'Certificado personalizado',
     letsEncryptEmail: `E-mail do ${common.letsEncrypt}`,
+    http3Warning1: 'HTTP/3 isn\'t a standard NGINX module, check the ', // TODO: translate
+    http3Warning2: 'NGINX QUIC readme ', // TODO: translate
+    http3Warning3: ' or the ', // TODO: translate
+    http3Warning4: 'Cloudflare quiche project ', // TODO: translate
+    http3Warning5: ' for how to build NGINX with HTTP/3!', // TODO: translate
 };

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/https.js
@@ -47,9 +47,4 @@ export default {
     ipv4Only: `${ipv4} apenas`,
     ipv6Only: `${ipv6} apenas`,
     ipv4AndIpv6: `${ipv4} & ${ipv6}`,
-    http3Warning1: 'HTTP/3 isn\'t a standard NGINX module, check the ', // TODO: translate 
-    http3Warning2: 'NGINX QUIC readme ', // TODO: translate 
-    http3Warning3: ' or the ', // TODO: translate 
-    http3Warning4: 'Cloudflare quiche project ', // TODO: translate 
-    http3Warning5: ' for how to build NGINX with HTTP/3!', // TODO: translate 
 };

--- a/src/nginxconfig/i18n/ru/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/ru/templates/domain_sections/https.js
@@ -42,4 +42,9 @@ export default {
     certificationType: 'Тип сертификации',
     customCertificate: 'Другой сертификат',
     letsEncryptEmail: `${common.letsEncrypt} email`,
+    http3Warning1: 'HTTP/3 isn\'t a standard NGINX module, check the ', // TODO: translate
+    http3Warning2: 'NGINX QUIC readme ', // TODO: translate
+    http3Warning3: ' or the ', // TODO: translate
+    http3Warning4: 'Cloudflare quiche project ', // TODO: translate
+    http3Warning5: ' for how to build NGINX with HTTP/3!', // TODO: translate
 };

--- a/src/nginxconfig/i18n/ru/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/ru/templates/global_sections/https.js
@@ -47,9 +47,4 @@ export default {
     ipv4Only: `только ${ipv4}`,
     ipv6Only: `только ${ipv6}`,
     ipv4AndIpv6: `${ipv4} & ${ipv6}`,
-    http3Warning1: 'HTTP/3 isn\'t a standard NGINX module, check the ', // TODO: translate 
-    http3Warning2: 'NGINX QUIC readme ', // TODO: translate 
-    http3Warning3: ' or the ', // TODO: translate 
-    http3Warning4: 'Cloudflare quiche project ', // TODO: translate 
-    http3Warning5: ' for how to build NGINX with HTTP/3!', // TODO: translate 
 };

--- a/src/nginxconfig/i18n/zh-cn/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/domain_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/zh-cn/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/domain_sections/https.js
@@ -42,4 +42,9 @@ export default {
     certificationType: '证书类型',
     customCertificate: '本地证书',
     letsEncryptEmail: `${common.letsEncrypt} 邮箱`,
+    http3Warning1: 'HTTP/3 isn\'t a standard NGINX module, check the ', // TODO: translate
+    http3Warning2: 'NGINX QUIC readme ', // TODO: translate
+    http3Warning3: ' or the ', // TODO: translate
+    http3Warning4: 'Cloudflare quiche project ', // TODO: translate
+    http3Warning5: ' for how to build NGINX with HTTP/3!', // TODO: translate
 };

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/https.js
@@ -47,9 +47,4 @@ export default {
     ipv4Only: `${ipv4}`,
     ipv6Only: `${ipv6}`,
     ipv4AndIpv6: `${ipv4} & ${ipv6}`,
-    http3Warning1: 'HTTP/3 isn\'t a standard NGINX module, check the ', // TODO: translate 
-    http3Warning2: 'NGINX QUIC readme ', // TODO: translate 
-    http3Warning3: ' or the ', // TODO: translate 
-    http3Warning4: 'Cloudflare quiche project ', // TODO: translate 
-    http3Warning5: ' for how to build NGINX with HTTP/3!', // TODO: translate 
 };

--- a/src/nginxconfig/i18n/zh-tw/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/domain_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/zh-tw/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/domain_sections/https.js
@@ -42,4 +42,9 @@ export default {
     certificationType: '證書類型',
     customCertificate: '本地證書',
     letsEncryptEmail: `${common.letsEncrypt} 郵箱`,
+    http3Warning1: 'HTTP/3 isn\'t a standard NGINX module, check the ', // TODO: translate
+    http3Warning2: 'NGINX QUIC readme ', // TODO: translate
+    http3Warning3: ' or the ', // TODO: translate
+    http3Warning4: 'Cloudflare quiche project ', // TODO: translate
+    http3Warning5: ' for how to build NGINX with HTTP/3!', // TODO: translate
 };

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/https.js
@@ -47,9 +47,4 @@ export default {
     ipv4Only: `${ipv4}`,
     ipv6Only: `${ipv6}`,
     ipv4AndIpv6: `${ipv4} & ${ipv6}`,
-    http3Warning1: 'HTTP/3 isn\'t a standard NGINX module, check the ', // TODO: translate 
-    http3Warning2: 'NGINX QUIC readme ', // TODO: translate 
-    http3Warning3: ' or the ', // TODO: translate 
-    http3Warning4: 'Cloudflare quiche project ', // TODO: translate 
-    http3Warning5: ' for how to build NGINX with HTTP/3!', // TODO: translate 
 };

--- a/src/nginxconfig/templates/domain_sections/https.vue
+++ b/src/nginxconfig/templates/domain_sections/https.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Conf generators, i18n strings

## What issue does this relate to?

N/A

### What should this PR do?

- Some i18n strings were in the wrong file (https http/3 in global, should be domain)
- Many files have been updated without the copyright year being update
- Applies more consistent lie wrapping to conf files
- The modules load rule was in the wrong place currently, resulting in nginx emerg outputs, now moved above events block

### What are the acceptance criteria?

Downloading the default configuration works and passes nginx -t following the on-site instructions. I have tested this on a fresh Ubuntu 20.04 LTS Droplet and it worked just fine :)