### PR TITLE
Hotfix: HTTP/3 strings use domainSections not globalSections

### DIFF
--- a/src/nginxconfig/templates/domain_sections/https.vue
+++ b/src/nginxconfig/templates/domain_sections/https.vue
@@ -229,15 +229,15 @@ THE SOFTWARE.
             <br />
             <div class="message is-warning">
                 <div class="message-body">
-                    {{ $t('templates.globalSections.https.http3Warning1') }}
-                    <ExternalLink :text="$t('templates.globalSections.https.http3Warning2')"
+                    {{ $t('templates.domainSections.https.http3Warning1') }}
+                    <ExternalLink :text="$t('templates.domainSections.https.http3Warning2')"
                                   link="https://quic.nginx.org/README"
                     ></ExternalLink>
-                    {{ $t('templates.globalSections.https.http3Warning3') }}
-                    <ExternalLink :text="$t('templates.globalSections.https.http3Warning4')"
+                    {{ $t('templates.domainSections.https.http3Warning3') }}
+                    <ExternalLink :text="$t('templates.domainSections.https.http3Warning4')"
                                   link="https://github.com/cloudflare/quiche/tree/master/extras/nginx"
                     ></ExternalLink>
-                    {{ $t('templates.globalSections.https.http3Warning5') }}
+                    {{ $t('templates.domainSections.https.http3Warning5') }}
                 </div>
             </div>
         </template>


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Domain HTTPS tab

## What issue does this relate to?

N/A

### What should this PR do?

Fixes the HTTP/3 warning strings, which were targeting the globalSections data instead of the domainSections data.

### What are the acceptance criteria?

When HTTP/3 is enabled in the HTTPS tab the warning strings render correctly at the bottom of the HTTPS tab.