### PR TITLE
Fix tab order

### DIFF
--- a/src/nginxconfig/templates/domain.vue
+++ b/src/nginxconfig/templates/domain.vue
@@ -63,13 +63,12 @@ THE SOFTWARE.
     import analytics from '../util/analytics';
     import isChanged from '../util/is_changed';
     import Presets from './domain_sections/presets';
-    import * as Sections from './domain_sections';
+    import Sections from './domain_sections';
 
-    const tabs = Object.values(Sections);
     const delegated = {
         hasUserInteraction: false,
         presets: Presets.delegated,
-        ...tabs.reduce((prev, tab) => {
+        ...Sections.reduce((prev, tab) => {
             prev[tab.key] = tab.delegated;
             return prev;
         }, {}),
@@ -86,8 +85,8 @@ THE SOFTWARE.
         },
         data() {
             return {
-                active: tabs[0].key,
-                tabs,
+                active: Sections[0].key,
+                tabs: Sections,
             };
         },
         computed: {

--- a/src/nginxconfig/templates/domain_sections/index.js
+++ b/src/nginxconfig/templates/domain_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,12 +24,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-export { default as Server } from './server';
-export { default as HTTPS } from './https';
-export { default as PHP } from './php';
-export { default as Python } from './python';
-export { default as ReverseProxy } from './reverse_proxy';
-export { default as Routing } from './routing';
-export { default as Logging } from './logging';
-export { default as Restrict } from './restrict';
-export { default as Onion } from './onion';
+import Server from './server';
+import HTTPS from './https';
+import PHP from './php';
+import Python from './python';
+import ReverseProxy from './reverse_proxy';
+import Routing from './routing';
+import Logging from './logging';
+import Restrict from './restrict';
+import Onion from './onion';
+
+export default [ Server, HTTPS, PHP, Python, ReverseProxy, Routing, Logging, Restrict, Onion ];

--- a/src/nginxconfig/templates/global.vue
+++ b/src/nginxconfig/templates/global.vue
@@ -56,10 +56,9 @@ THE SOFTWARE.
 <script>
     import analytics from '../util/analytics';
     import isChanged from '../util/is_changed';
-    import * as Sections from './global_sections';
+    import Sections from './global_sections';
 
-    const tabs = Object.values(Sections);
-    const delegated = tabs.reduce((prev, tab) => {
+    const delegated = Sections.reduce((prev, tab) => {
         prev[tab.key] = tab.delegated;
         return prev;
     }, {});
@@ -72,8 +71,8 @@ THE SOFTWARE.
         },
         data() {
             return {
-                active: tabs[0].key,
-                tabs,
+                active: Sections[0].key,
+                tabs: Sections,
             };
         },
         computed: {

--- a/src/nginxconfig/templates/global_sections/index.js
+++ b/src/nginxconfig/templates/global_sections/index.js
@@ -24,12 +24,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-export { default as HTTPS } from './https';
-export { default as Security } from './security';
-export { default as Python } from './python';
-export { default as ReverseProxy } from './reverse_proxy';
-export { default as Performance } from './performance';
-export { default as Logging } from './logging';
-export { default as NGINX } from './nginx';
-export { default as Docker } from './docker';
-export { default as Tools } from './tools';
+import HTTPS from './https';
+import Security from './security';
+import Python from './python';
+import ReverseProxy from './reverse_proxy';
+import Performance from './performance';
+import Logging from './logging';
+import NGINX from './nginx';
+import Docker from './docker';
+import Tools from './tools';
+
+export default [ HTTPS, Security, Python, ReverseProxy, Performance, Logging, NGINX, Docker, Tools ];

--- a/src/nginxconfig/templates/setup.vue
+++ b/src/nginxconfig/templates/setup.vue
@@ -64,9 +64,7 @@ THE SOFTWARE.
     import Tar from 'memory-tar-create';
     import ClipboardJS from 'clipboard';
     import analytics from '../util/analytics';
-    import * as Sections from './setup_sections';
-
-    const tabs = Object.values(Sections);
+    import Sections from './setup_sections';
 
     export default {
         name: 'Setup',
@@ -75,8 +73,8 @@ THE SOFTWARE.
         },
         data() {
             return {
-                active: tabs[0].key,
-                tabs,
+                active: Sections[0].key,
+                tabs: Sections,
             };
         },
         computed: {

--- a/src/nginxconfig/templates/setup_sections/index.js
+++ b/src/nginxconfig/templates/setup_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-export { default as Download } from './download';
-export { default as SSL } from './ssl';
-export { default as Certbot } from './certbot';
-export { default as GoLive } from './go_live';
+import Download from './download';
+import SSL from './ssl';
+import Certbot from './certbot';
+import GoLive from './go_live';
+
+export default [ Download, SSL, Certbot, GoLive ];


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Section exports/imports

## What issue does this relate to?

N/A

### What should this PR do?

Replaces the direct section exports with a single exported array to ensure the section tabs are rendered in the correct order and don't rely on implicit ordering which no longer seems to work.

### What are the acceptance criteria?

Tabs rendered match the order defined in the arrays.