### PR TITLE
Reduce the query param cut-off to 1000 chars 

### DIFF
--- a/src/nginxconfig/util/share_query.js
+++ b/src/nginxconfig/util/share_query.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/util/share_query.js
+++ b/src/nginxconfig/util/share_query.js
@@ -30,5 +30,5 @@ import exportData from './export_data';
 export default (domains, global) => {
     const data = exportData(domains, global);
     const query = qs.stringify(data, { allowDots: true });
-    return `${query.length > 4000 ? '#' : ''}${query.length ? '?' : ''}${query}`;
+    return `${query.length > 1000 ? '#' : ''}${query.length ? '?' : ''}${query}`;
 };


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Share URL util

## What issue does this relate to?

Resolves #258

### What should this PR do?

Reduces the cut-off on the share URL query params before injecting the `#` symbol to be only 1000 chars. Hopefully, this should eliminate large query param payloads being sent to the server and resulting in 502s.

### What are the acceptance criteria?

Small config uses query params without `#`. Big config injects the `#` symbol and does not cause a 502 when reloaded.