### PR TITLE
Ensure bundle analysis is always enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "build:tool": "vue-cli-service build src/nginxconfig/mount.js --no-clean",
     "dev": "npm run build:template && npm run build:prism && npm run dev:tool",
     "dev:tool": "vue-cli-service serve src/nginxconfig/mount.js",
-    "analyze": "npm run build:tool -- --analyze",
     "deploy:spaces:comment": "do-vue comment nginxconfig",
     "test": "npm run test:eslint && npm run test:sass-lint && npm run test:i18n-packs && npm run test:jest",
     "test:jest": "jest /test/.*.js?$",

--- a/vue.config.js
+++ b/vue.config.js
@@ -40,8 +40,8 @@ module.exports = {
     configureWebpack: {
         node: false, // Disable Node.js polyfills (Buffer etc.) -- This will be default in Webpack 5
         plugins: [
-            process.argv.includes('--analyze') && new BundleAnalyzerPlugin(),
-            process.argv.includes('--analyze') && new DuplicatePackageCheckerPlugin(),
+            new BundleAnalyzerPlugin({ analyzerMode: 'static', openAnalyzer: false }),
+            new DuplicatePackageCheckerPlugin(),
             new WebpackRequireFrom({ replaceSrcMethodName: '__replaceWebpackDynamicImport' }),
         ].filter(x => !!x),
     },


### PR DESCRIPTION
## Type of Change

- **Build Scripts:** Webpack

## What issue does this relate to?

N/A

### What should this PR do?

Ensures that bundle analyzer is always enabled, matching how we do things with do-vue --  this should ensure that the build analysis link in the commit preview comments works.

### What are the acceptance criteria?

Build analysis link works in commit preview comment.