### PR TITLE
Replace obsoleted X-Frame-Options with frame-ancestors

### DIFF
--- a/src/nginxconfig/generators/conf/security.conf.js
+++ b/src/nginxconfig/generators/conf/security.conf.js
@@ -30,7 +30,6 @@ export default (domains, global) => {
     const config = [];
 
     config.push(['# security headers', '']);
-    config.push(['add_header X-Frame-Options', '"SAMEORIGIN" always']);
     config.push(['add_header X-XSS-Protection', '"1; mode=block" always']);
     config.push(['add_header X-Content-Type-Options', '"nosniff" always']);
     config.push(['add_header Referrer-Policy', `"${global.security.referrerPolicy.computed}" always`]);

--- a/src/nginxconfig/templates/global_sections/security.vue
+++ b/src/nginxconfig/templates/global_sections/security.vue
@@ -161,7 +161,7 @@ THE SOFTWARE.
             enabled: true,
         },
         contentSecurityPolicy: {
-            default: 'default-src \'self\' http: https: data: blob: \'unsafe-inline\'',
+            default: 'default-src \'self\' http: https: data: blob: \'unsafe-inline\'; frame-ancestors \'self\';',
             enabled: true,
         },
         serverTokens: {


### PR DESCRIPTION
### Type of Change
- **Tool Source:**
  - src/nginxconfig/generators/conf/security.conf.js
  - src/nginxconfig/templates/global_sections/security.vue

### What should this PR do?
- [Replace obsoleted X-Frame-Options with frame-ancestors](https://www.w3.org/TR/CSP2/#frame-ancestors-and-frame-options)

### What are the acceptance criteria?
- Tests pass
- WordPress warning still works
- `add_header X-Frame-Options           "SAMEORIGIN" always;` does **not** populate
- `add_header Content-Security-Policy   "... frame-ancestors 'self';"` always; does populate