### PR TITLE
Improve WordPress CSP warning detection

### DIFF
--- a/src/nginxconfig/i18n/en/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/security.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -27,6 +27,6 @@ THE SOFTWARE.
 import common from '../../common';
 
 export default {
-    whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `When using ${common.wordPress}, <code class="slim">'unsafe-eval'</code> is often required in the Content Security Policy to allow the admin panel to function correctly.`,
+    whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `When using ${common.wordPress}, <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code> is often required in the Content Security Policy to allow the admin panel to function correctly.`,
     security: 'Security',
 };

--- a/src/nginxconfig/i18n/fr/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/fr/templates/global_sections/security.js
@@ -27,6 +27,6 @@ THE SOFTWARE.
 import common from '../../common';
 
 export default {
-    whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `Lors de l'utilisation de ${common.wordPress}, <code class="slim">'unsafe-eval'</code> est fréquemment exigé par la Politique de Sécurité du Contenu pour assurer le bon fonctionnement du panneau d'administration.`,
+    whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `Lors de l'utilisation de ${common.wordPress}, <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code> est fréquemment exigé par la Politique de Sécurité du Contenu pour assurer le bon fonctionnement du panneau d'administration.`,
     security: 'Sécurité',
 };

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/security.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -27,6 +27,6 @@ THE SOFTWARE.
 import common from '../../common';
 
 export default {
-    whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `Ao utilizar o ${common.wordPress}, <code class="slim">'unsafe-eval'</code> é frequentemente exigido na Política de Segurança de Conteúdo para permitir que o painel de administração funcione corretamente.`,
+    whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `Ao utilizar o ${common.wordPress}, <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code> é frequentemente exigido na Política de Segurança de Conteúdo para permitir que o painel de administração funcione corretamente.`,
     security: 'Segurança',
 };

--- a/src/nginxconfig/i18n/ru/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/ru/templates/global_sections/security.js
@@ -27,6 +27,6 @@ THE SOFTWARE.
 import common from '../../common';
 
 export default {
-    whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `Во время использования ${common.wordPress}, <code class="slim">'unsafe-eval'</code> часто требуется в Content Security Policy, чтобы панель администратора работала исправно.`,
+    whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `Во время использования ${common.wordPress}, <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code> часто требуется в Content Security Policy, чтобы панель администратора работала исправно.`,
     security: 'Безопасность',
 };

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/security.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -27,6 +27,6 @@ THE SOFTWARE.
 import common from '../../common';
 
 export default {
-    whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `当使用${common.wordPress}时，, <code class="slim">'unsafe-eval'</code>经常需要在内容安全策略中，以允许管理面板的功能正确。`,
+    whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `当使用${common.wordPress}时，, <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code>经常需要在内容安全策略中，以允许管理面板的功能正确。`,
     security: '安全',
 };

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/security.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -27,6 +27,6 @@ THE SOFTWARE.
 import common from '../../common';
 
 export default {
-    whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `當使用${common.wordPress}時，, <code class="slim">'unsafe-eval'</code>經常需要在內容安全策略中，以允許管理面板的功能正確。`,
+    whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `當使用${common.wordPress}時，, <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code>經常需要在內容安全策略中，以允許管理面板的功能正確。`,
     security: '安全',
 };

--- a/src/nginxconfig/templates/global_sections/security.vue
+++ b/src/nginxconfig/templates/global_sections/security.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -55,7 +55,7 @@ THE SOFTWARE.
                                :placeholder="$props.data.contentSecurityPolicy.default"
                         />
                     </div>
-                    <div v-if="hasWordPress && !hasUnsafeEval" class="control">
+                    <div v-if="hasWordPress && !hasWordPressUnsafeEval" class="control">
                         <label class="text message is-warning">
                             <span class="message-body"
                                   v-html="$t('templates.globalSections.security.whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality')"
@@ -199,11 +199,12 @@ THE SOFTWARE.
             hasWordPress() {
                 return this.$parent.$parent.$data.domains.some(d => d && d.php.wordPressRules.computed);
             },
-            hasUnsafeEval() {
-                return this.$props.data.contentSecurityPolicy.computed.includes('\'unsafe-eval\'');
+            hasWordPressUnsafeEval() {
+                return this.$props.data.contentSecurityPolicy.computed
+                    .match(/(default|script)-src[^;]+'self'[^;]+'unsafe-inline'[^;]+'unsafe-eval'[^;]*;/) !== null;
             },
             hasWarnings() {
-                return this.hasWordPress && !this.hasUnsafeEval;
+                return this.hasWordPress && !this.hasWordPressUnsafeEval;
             },
         },
         watch: {


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Global security template + i18n files

## What issue does this relate to?

Follow-up to #272

### What should this PR do?

Improves how we handle detection of the WordPress unsafe-eval warning.

### What are the acceptance criteria?

With the PHP WordPress rules enabled:

- If ` 'unsafe-eval'` is added to the end of the `default-src` directive, the warning should hide.
- If `script-src 'self' 'unsafe-inline' 'unsafe-eval';` is added as a new directive, the warning should hide.