### PR TITLE
add NGINX implementation of proxy_set_header Forwarded

### DIFF
--- a/src/nginxconfig/generators/conf/nginx.conf.js
+++ b/src/nginxconfig/generators/conf/nginx.conf.js
@@ -196,13 +196,19 @@ export default (domains, global) => {
             'default': 'upgrade',
             '""': 'close',
         }]);
+        // See https://www.nginx.com/resources/wiki/start/topics/examples/forwarded/
         config.http.push(['map $remote_addr $proxy_forwarded_elem', {
+            '# IPv4 addresses can be sent as-is': '',
             '~^[0-9.]+$': '"for=$remote_addr"',
+            '# IPv6 addresses need to be bracketed and quoted': '',
             '~^[0-9A-Fa-f:.]+$': '"for=\\"[$remote_addr]\\""',
+            '# Unix domain socket names cannot be represented in RFC 7239 syntax': '',
             'default': '"for=unknown"',
         }]);
         config.http.push(['map $http_forwarded $proxy_add_forwarded', {
+            '# If the incoming Forwarded header is syntactically valid, append to it': '',
             '': '"~^(,[ \\\\t]*)*([!#$%&\'*+.^_`|~0-9A-Za-z-]+=([!#$%&\'*+.^_`|~0-9A-Za-z-]+|\\"([\\\\t \\\\x21\\\\x23-\\\\x5B\\\\x5D-\\\\x7E\\\\x80-\\\\xFF]|\\\\\\\\[\\\\t \\\\x21-\\\\x7E\\\\x80-\\\\xFF])*\\"))?(;([!#$%&\'*+.^_`|~0-9A-Za-z-]+=([!#$%&\'*+.^_`|~0-9A-Za-z-]+|\\"([\\\\t \\\\x21\\\\x23-\\\\x5B\\\\x5D-\\\\x7E\\\\x80-\\\\xFF]|\\\\\\\\[\\\\t \\\\x21-\\\\x7E\\\\x80-\\\\xFF])*\\"))?)*([ \\\\t]*,([ \\\\t]*([!#$%&\'*+.^_`|~0-9A-Za-z-]+=([!#$%&\'*+.^_`|~0-9A-Za-z-]+|\\"([\\\\t \\\\x21\\\\x23-\\\\x5B\\\\x5D-\\\\x7E\\\\x80-\\\\xFF]|\\\\\\\\[\\\\t \\\\x21-\\\\x7E\\\\x80-\\\\xFF])*\\"))?(;([!#$%&\'*+.^_`|~0-9A-Za-z-]+=([!#$%&\'*+.^_`|~0-9A-Za-z-]+|\\"([\\\\t \\\\x21\\\\x23-\\\\x5B\\\\x5D-\\\\x7E\\\\x80-\\\\xFF]|\\\\\\\\[\\\\t \\\\x21-\\\\x7E\\\\x80-\\\\xFF])*\\"))?)*)?)*$" "$http_forwarded, $proxy_forwarded_elem"',
+            '# Otherwise, replace it': '',
             'default': '"$proxy_forwarded_elem"',
         }]);
     }

--- a/src/nginxconfig/generators/conf/nginx.conf.js
+++ b/src/nginxconfig/generators/conf/nginx.conf.js
@@ -196,6 +196,15 @@ export default (domains, global) => {
             'default': 'upgrade',
             '""': 'close',
         }]);
+        config.http.push(['map $remote_addr $proxy_forwarded_elem', {
+            '~^[0-9.]+$': '"for=$remote_addr"',
+            '~^[0-9A-Fa-f:.]+$': '"for=\\"[$remote_addr]\\""',
+            'default': '"for=unknown"',
+        }]);
+        config.http.push(['map $http_forwarded $proxy_add_forwarded', {
+            '': '"~^(,[ \\\\t]*)*([!#$%&\'*+.^_`|~0-9A-Za-z-]+=([!#$%&\'*+.^_`|~0-9A-Za-z-]+|\\"([\\\\t \\\\x21\\\\x23-\\\\x5B\\\\x5D-\\\\x7E\\\\x80-\\\\xFF]|\\\\\\\\[\\\\t \\\\x21-\\\\x7E\\\\x80-\\\\xFF])*\\"))?(;([!#$%&\'*+.^_`|~0-9A-Za-z-]+=([!#$%&\'*+.^_`|~0-9A-Za-z-]+|\\"([\\\\t \\\\x21\\\\x23-\\\\x5B\\\\x5D-\\\\x7E\\\\x80-\\\\xFF]|\\\\\\\\[\\\\t \\\\x21-\\\\x7E\\\\x80-\\\\xFF])*\\"))?)*([ \\\\t]*,([ \\\\t]*([!#$%&\'*+.^_`|~0-9A-Za-z-]+=([!#$%&\'*+.^_`|~0-9A-Za-z-]+|\\"([\\\\t \\\\x21\\\\x23-\\\\x5B\\\\x5D-\\\\x7E\\\\x80-\\\\xFF]|\\\\\\\\[\\\\t \\\\x21-\\\\x7E\\\\x80-\\\\xFF])*\\"))?(;([!#$%&\'*+.^_`|~0-9A-Za-z-]+=([!#$%&\'*+.^_`|~0-9A-Za-z-]+|\\"([\\\\t \\\\x21\\\\x23-\\\\x5B\\\\x5D-\\\\x7E\\\\x80-\\\\xFF]|\\\\\\\\[\\\\t \\\\x21-\\\\x7E\\\\x80-\\\\xFF])*\\"))?)*)?)*$" "$http_forwarded, $proxy_forwarded_elem"',
+            'default': '"$proxy_forwarded_elem"',
+        }]);
     }
 
     // Configs!

--- a/src/nginxconfig/generators/conf/proxy.conf.js
+++ b/src/nginxconfig/generators/conf/proxy.conf.js
@@ -35,7 +35,12 @@ export default global => {
     config['proxy_set_header Connection'] = '$connection_upgrade';
     config['proxy_set_header Host'] = '$host';
     config['proxy_set_header X-Real-IP'] = '$remote_addr';
-    config['proxy_set_header X-Forwarded-For'] = '$proxy_add_x_forwarded_for';
+    config['proxy_set_header Forwarded'] = '$proxy_add_forwarded';
+    if (global.reverseProxy.proxyCoexistenceXForwarded.computed == 'passOn') {
+        config['proxy_set_header X-Forwarded-For'] = '$proxy_add_x_forwarded_for';
+    } else {
+        config['proxy_set_header X-Forwarded-For'] = '""';
+    }
     config['proxy_set_header X-Forwarded-Proto'] = '$scheme';
     config['proxy_set_header X-Forwarded-Host'] = '$host';
     config['proxy_set_header X-Forwarded-Port'] = '$server_port';

--- a/src/nginxconfig/generators/conf/proxy.conf.js
+++ b/src/nginxconfig/generators/conf/proxy.conf.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -38,12 +38,16 @@ export default global => {
     config['proxy_set_header Forwarded'] = '$proxy_add_forwarded';
     if (global.reverseProxy.proxyCoexistenceXForwarded.computed == 'passOn') {
         config['proxy_set_header X-Forwarded-For'] = '$proxy_add_x_forwarded_for';
+        config['proxy_set_header X-Forwarded-Proto'] = '$scheme';
+        config['proxy_set_header X-Forwarded-Host'] = '$host';
+        config['proxy_set_header X-Forwarded-Port'] = '$server_port';
     } else {
         config['proxy_set_header X-Forwarded-For'] = '""';
+        config['proxy_set_header X-Forwarded-Proto'] = '""';
+        config['proxy_set_header X-Forwarded-Host'] = '""';
+        config['proxy_set_header X-Forwarded-Port'] = '""';
     }
-    config['proxy_set_header X-Forwarded-Proto'] = '$scheme';
-    config['proxy_set_header X-Forwarded-Host'] = '$host';
-    config['proxy_set_header X-Forwarded-Port'] = '$server_port';
+    
 
     config['# Proxy timeouts'] = '';
     config['proxy_connect_timeout'] = global.reverseProxy.proxyConnectTimeout.computed;

--- a/src/nginxconfig/i18n/en/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/en/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/reverse_proxy.js
@@ -26,7 +26,11 @@ THE SOFTWARE.
 
 import common from '../../common';
 
+const legacyXForwarded = 'Legacy X-Forwarded-* headers';
+
 export default {
     reverseProxyMustBeEnabledOnOneSite: `${common.reverseProxy} must be enabled on at least one site to configure global ${common.reverseProxyLower} settings.`,
     seconds: 'seconds',
+    passOn: `${legacyXForwarded} passed on`,
+    remove: `${legacyXForwarded} actively removed`,
 };

--- a/src/nginxconfig/i18n/fr/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/fr/templates/global_sections/reverse_proxy.js
@@ -26,7 +26,11 @@ THE SOFTWARE.
 
 import common from '../../common';
 
+const legacyXForwarded = 'Legacy X-Forwarded-* headers'; // TODO: translate
+
 export default {
     reverseProxyMustBeEnabledOnOneSite: `Le ${common.reverseProxyLower} doit être activé sur au moins un site pour configurer les paramètres globaux du ${common.reverseProxyLower}.`,
     seconds: 'secondes',
+    passOn: `${legacyXForwarded} passed on`, // TODO: translate
+    remove: `${legacyXForwarded} actively removed`, // TODO: translate
 };

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/reverse_proxy.js
@@ -26,7 +26,11 @@ THE SOFTWARE.
 
 import common from '../../common';
 
+const legacyXForwarded = 'Legacy X-Forwarded-* headers'; // TODO: translate
+
 export default {
     reverseProxyMustBeEnabledOnOneSite: `O ${common.reverseProxy} deve estar habilitado em pelo menos um site para definir as configurações globais do ${common.reverseProxyLower}.`,
     seconds: 'segundos',
+    passOn: `${legacyXForwarded} passed on`, // TODO: translate
+    remove: `${legacyXForwarded} actively removed`, // TODO: translate
 };

--- a/src/nginxconfig/i18n/ru/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/ru/templates/global_sections/reverse_proxy.js
@@ -26,7 +26,11 @@ THE SOFTWARE.
 
 import common from '../../common';
 
+const legacyXForwarded = 'Legacy X-Forwarded-* headers'; // TODO: translate
+
 export default {
     reverseProxyMustBeEnabledOnOneSite: `${common.reverseProxy} должен быть включен как минимум на одном сайте, чтобы сконфигурировать глобальные настройки ${common.reverseProxyLower}.`,
     seconds: 'секунд',
+    passOn: `${legacyXForwarded} passed on`, // TODO: translate
+    remove: `${legacyXForwarded} actively removed`, // TODO: translate
 };

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/reverse_proxy.js
@@ -26,7 +26,11 @@ THE SOFTWARE.
 
 import common from '../../common';
 
+const legacyXForwarded = 'Legacy X-Forwarded-* headers'; // TODO: translate
+
 export default {
     reverseProxyMustBeEnabledOnOneSite: `必须在至少一个站点上启用${common.reverseProxy}才能配置全局${common.reverseProxy}设置。`,
     seconds: '秒',
+    passOn: `${legacyXForwarded} passed on`, // TODO: translate
+    remove: `${legacyXForwarded} actively removed`, // TODO: translate
 };

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/reverse_proxy.js
@@ -26,7 +26,11 @@ THE SOFTWARE.
 
 import common from '../../common';
 
+const legacyXForwarded = 'Legacy X-Forwarded-* headers'; // TODO: translate
+
 export default {
     reverseProxyMustBeEnabledOnOneSite: `必須在至少一個網站上啟用${common.reverseProxy}才能配寘全域${common.reverseProxy}設定。`,
     seconds: '秒',
+    passOn: `${legacyXForwarded} passed on`, // TODO: translate
+    remove: `${legacyXForwarded} actively removed`, // TODO: translate
 };

--- a/src/nginxconfig/templates/global_sections/reverse_proxy.vue
+++ b/src/nginxconfig/templates/global_sections/reverse_proxy.vue
@@ -113,11 +113,34 @@ THE SOFTWARE.
                     </div>
                 </div>
             </div>
+
+            <div class="field is-horizontal">
+                <div class="field-label">
+                    <label class="label">Coexistence with X-Forwarded-*</label>
+                </div>
+                <div class="field-body">
+                    <div class="field">
+                        <div class="field">
+                            <div v-for="(name, value) in $props.data.proxyCoexistenceXForwarded.options"
+                                 :class="`control${proxyCoexistenceXForwardedChanged && value === proxyCoexistenceXForwarded ? ' is-changed' : ''}`"
+                            >
+                                <div class="radio">
+                                    <PrettyRadio v-model="proxyCoexistenceXForwarded" :value="value" class="p-default p-round p-fill p-icon">
+                                        <i slot="extra" class="icon fas fa-check"></i>
+                                        {{ $t(name) }}
+                                    </PrettyRadio>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </template>
     </div>
 </template>
 
 <script>
+    import PrettyRadio from 'pretty-checkbox-vue/radio';
     import delegatedFromDefaults from '../../util/delegated_from_defaults';
     import computedFromDefaults from '../../util/computed_from_defaults';
 
@@ -135,6 +158,14 @@ THE SOFTWARE.
         proxyReadTimeout: {
             default: 60,
             computed: '60s', // We use a watcher to append 's'
+            enabled: false,
+        },
+        proxyCoexistenceXForwarded: {
+            default: 'passOn',
+            options: {
+                passOn: 'templates.globalSections.reverseProxy.passOn', // i18n key
+                remove: 'templates.globalSections.reverseProxy.remove', // i18n key
+            },
             enabled: false,
         },
     };
@@ -156,6 +187,9 @@ THE SOFTWARE.
         display: 'common.reverseProxy',                             // Display name for tab (i18n key)
         key: 'reverseProxy',                                        // Key for data in parent
         delegated: delegatedFromDefaults(defaults),                 // Data the parent will present here
+        components: {
+            PrettyRadio,
+        },
         props: {
             data: Object,                                           // Data delegated back to us from parent
         },
@@ -179,6 +213,8 @@ THE SOFTWARE.
                             this.$props.data.proxySendTimeout.computed = this.$props.data.proxySendTimeout.value;
                             this.$props.data.proxyReadTimeout.enabled = true;
                             this.$props.data.proxyReadTimeout.computed = this.$props.data.proxyReadTimeout.value;
+                            this.$props.data.proxyCoexistenceXForwarded.enabled = true;
+                            this.$props.data.proxyCoexistenceXForwarded.computed = this.$props.data.proxyCoexistenceXForwarded.value;
                             return;
                         }
                     }
@@ -190,6 +226,8 @@ THE SOFTWARE.
                     this.$props.data.proxySendTimeout.computed = '';
                     this.$props.data.proxyReadTimeout.enabled = false;
                     this.$props.data.proxyReadTimeout.computed = '';
+                    this.$props.data.proxyCoexistenceXForwarded.enabled = false;
+                    this.$props.data.proxyCoexistenceXForwarded.computed = '';
                 },
                 deep: true,
             },

--- a/src/nginxconfig/templates/global_sections/reverse_proxy.vue
+++ b/src/nginxconfig/templates/global_sections/reverse_proxy.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at


### PR DESCRIPTION
### Type of Change
- **Tool Source:**
  -  generators/conf/nginx.conf.js
  - generators/conf/proxy.conf.js 
  - templates/global_sections/reverse_proxy.vue 
  - localizations (EN done, others need translating)

### What issue does this relate to?
Closes #270

### What should this PR do?
Add NGINX implementation of Forwarded header with two options for coexistence with X-Forwarded-*

### What are the acceptance criteria?
Tests pass
New mappings and `proxy_set_header Forwarded $proxy_add_forwarded;` populate as **default**
`proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; `populates as **default**
`proxy_set_header X-Forwarded-For "";` populates as option