### PR TITLE
Implement Permissions-Policy header

### DIFF
--- a/src/nginxconfig/generators/conf/security.conf.js
+++ b/src/nginxconfig/generators/conf/security.conf.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/generators/conf/security.conf.js
+++ b/src/nginxconfig/generators/conf/security.conf.js
@@ -37,6 +37,9 @@ export default (domains, global) => {
     if (global.security.contentSecurityPolicy.computed)
         config.push(['add_header Content-Security-Policy', `"${global.security.contentSecurityPolicy.computed}" always`]);
 
+    if (global.security.permissionsPolicy.computed)
+        config.push(['add_header Permissions-Policy', `"${global.security.permissionsPolicy.computed}" always`]);
+
     // Every domain has HSTS enabled, and they all have same hstsSubdomains/hstsPreload settings
     if (commonHsts(domains)) {
         const commonHSTSSubdomains = domains.length && domains[0].https.hstsSubdomains.computed;

--- a/src/nginxconfig/templates/global_sections/security.vue
+++ b/src/nginxconfig/templates/global_sections/security.vue
@@ -68,6 +68,23 @@ THE SOFTWARE.
 
         <div class="field is-horizontal">
             <div class="field-label">
+                <label class="label">Permissions-Policy</label>
+            </div>
+            <div class="field-body">
+                <div class="field">
+                    <div :class="`control${permissionsPolicyChanged ? ' is-changed' : ''}`">
+                        <input v-model="permissionsPolicy"
+                               class="input"
+                               type="text"
+                               :placeholder="$props.data.permissionsPolicy.default"
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="field is-horizontal">
+            <div class="field-label">
                 <label class="label">server_tokens</label>
             </div>
             <div class="field-body">
@@ -162,6 +179,10 @@ THE SOFTWARE.
         },
         contentSecurityPolicy: {
             default: 'default-src \'self\' http: https: data: blob: \'unsafe-inline\'; frame-ancestors \'self\';',
+            enabled: true,
+        },
+        permissionsPolicy: {
+            default: 'interest-cohort=()',
             enabled: true,
         },
         serverTokens: {


### PR DESCRIPTION
## Type of Change
- **Tool Source:** <!-- Which part of the tool source? Vue, JS, SCSS? -->
  - generators/conf/security.conf.js
  - templates/global_sections/security.vue 

## What issue does this relate to?
Resolves #281

### What should this PR do?
* Implement a `Permissions-Policy` text input field similar to CSP
* By default block FloC from tracking a users website
* Add the header in the nginx config

### What are the acceptance criteria?
* New header in Global Config > Security
* Able to change the input of `Permissions-Policy` and it reflects in the nginx config

Default:
![image](https://user-images.githubusercontent.com/8492901/123308932-34688e00-d51c-11eb-9b05-60aeef2e8ac9.png)
![image](https://user-images.githubusercontent.com/8492901/123309035-53672000-d51c-11eb-9ac7-e47e9d211333.png)

Header removed:
![image](https://user-images.githubusercontent.com/8492901/123309086-611ca580-d51c-11eb-8234-a822f476d4fc.png)
![image](https://user-images.githubusercontent.com/8492901/123309119-6da0fe00-d51c-11eb-81c0-7da3d7c8fdea.png)

Expected use-case:
![image](https://user-images.githubusercontent.com/8492901/123309253-9aedac00-d51c-11eb-96c5-821eb137da00.png)
![image](https://user-images.githubusercontent.com/8492901/123309285-a3de7d80-d51c-11eb-8d2b-26bac028e016.png)
