### PR TITLE
reuseport is not HTTP/3 only

### DIFF
--- a/src/nginxconfig/generators/conf/nginx.conf.js
+++ b/src/nginxconfig/generators/conf/nginx.conf.js
@@ -222,9 +222,10 @@ export default (domains, global) => {
 
     // Single file configs
     if (!global.tools.modularizedStructure.computed) {
+        const ipPortPairs = new Set();
         for (const domain of domains) {
             config.http.push([`# ${domain.server.domain.computed}`, '']);
-            config.http.push(...websiteConf(domain, domains, global));
+            config.http.push(...websiteConf(domain, domains, global, ipPortPairs));
         }
     }
 

--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -61,7 +61,7 @@ const httpsListen = domain => {
 
     // HTTPS
     config.push(['listen',
-        `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}443 ssl${domain.https.http2.computed ? ' http2' : ''}`]);
+        `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}443 ssl${domain.https.http2.computed ? ' http2' : ''}${domain.https.portReuse.computed ? ' reuseport' : ''}`]);
 
     // HTTP/3
     if (domain.https.http3.computed)
@@ -71,7 +71,7 @@ const httpsListen = domain => {
     // v6
     if (domain.server.listenIpv6.computed)
         config.push(['listen',
-            `[${domain.server.listenIpv6.computed}]:443 ssl${domain.https.http2.computed ? ' http2' : ''}`]);
+            `[${domain.server.listenIpv6.computed}]:443 ssl${domain.https.http2.computed ? ' http2' : ''}${domain.https.portReuse.computed ? ' reuseport' : ''}`]);
 
     // v6 HTTP/3
     if (domain.server.listenIpv6.computed && domain.https.http3.computed)

--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -66,7 +66,7 @@ const httpsListen = domain => {
     // HTTP/3
     if (domain.https.http3.computed)
         config.push(['listen',
-            `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}443 http3${domain.https.portReuse.computed ? ' reuseport' : ''}`]);
+            `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}443 http3`]);
 
     // v6
     if (domain.server.listenIpv6.computed)
@@ -76,7 +76,7 @@ const httpsListen = domain => {
     // v6 HTTP/3
     if (domain.server.listenIpv6.computed && domain.https.http3.computed)
         config.push(['listen',
-            `[${domain.server.listenIpv6.computed}]:443 http3${domain.https.portReuse.computed ? ' reuseport' : ''}`]);
+            `[${domain.server.listenIpv6.computed}]:443 http3`]);
 
     return config;
 };

--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -56,12 +56,12 @@ const sslConfig = (domain, global) => {
     return config;
 };
 
-const httpsListen = domain => {
+const httpsListen = (domain, global) => {
     const config = [];
 
     // HTTPS
     config.push(['listen',
-        `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}443 ssl${domain.https.http2.computed ? ' http2' : ''}${domain.https.portReuse.computed ? ' reuseport' : ''}`]);
+        `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}443 ssl${domain.https.http2.computed ? ' http2' : ''}${global.https.portReuse.computed ? ' reuseport' : ''}`]);
 
     // HTTP/3
     if (domain.https.http3.computed)
@@ -71,7 +71,7 @@ const httpsListen = domain => {
     // v6
     if (domain.server.listenIpv6.computed)
         config.push(['listen',
-            `[${domain.server.listenIpv6.computed}]:443 ssl${domain.https.http2.computed ? ' http2' : ''}${domain.https.portReuse.computed ? ' reuseport' : ''}`]);
+            `[${domain.server.listenIpv6.computed}]:443 ssl${domain.https.http2.computed ? ' http2' : ''}${global.https.portReuse.computed ? ' reuseport' : ''}`]);
 
     // v6 HTTP/3
     if (domain.server.listenIpv6.computed && domain.https.http3.computed)
@@ -95,8 +95,8 @@ const httpListen = domain => {
     return config;
 };
 
-const listenConfig = domain => {
-    if (domain.https.https.computed) return httpsListen(domain);
+const listenConfig = (domain, global) => {
+    if (domain.https.https.computed) return httpsListen(domain, global);
     return httpListen(domain);
 };
 
@@ -141,7 +141,7 @@ export default (domain, domains, global) => {
     if (!domain.https.https.computed || !domain.https.forceHttps.computed) serverConfig.push(...httpListen(domain));
 
     // HTTPS
-    if (domain.https.https.computed) serverConfig.push(...httpsListen(domain));
+    if (domain.https.https.computed) serverConfig.push(...httpsListen(domain, global));
 
     serverConfig.push(['server_name',
         `${domain.server.wwwSubdomain.computed ? 'www.' : ''}${domain.server.domain.computed}`]);
@@ -340,7 +340,7 @@ export default (domain, domains, global) => {
         // Build the server config on its own before adding it to the parent config
         const cdnConfig = [];
 
-        cdnConfig.push(...listenConfig(domain));
+        cdnConfig.push(...listenConfig(domain, global));
         cdnConfig.push(['server_name', `cdn.${domain.server.domain.computed}`]);
         cdnConfig.push(['root', `${domain.server.path.computed}${domain.server.documentRoot.computed}`]);
 
@@ -383,7 +383,7 @@ export default (domain, domains, global) => {
         // Build the server config on its own before adding it to the parent config
         const redirectConfig = [];
 
-        redirectConfig.push(...listenConfig(domain));
+        redirectConfig.push(...listenConfig(domain, global));
         redirectConfig.push(['server_name',
             `${domain.server.wwwSubdomain.computed ? '' : '*'}.${domain.server.domain.computed}`]);
 

--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -56,56 +56,75 @@ const sslConfig = (domain, global) => {
     return config;
 };
 
-const httpsListen = (domain, global) => {
+const httpsListen = (domain, global, ipPortPairs) => {
     const config = [];
+
+    // Check if reuseport needs to be set
+    const ipPortV4 = `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}443`;
+    const reusePortV4 = global.https.portReuse.computed && !ipPortPairs.has(ipPortV4);
+    if (reusePortV4) ipPortPairs.add(ipPortV4);
 
     // HTTPS
     config.push(['listen',
-        `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}443 ssl${domain.https.http2.computed ? ' http2' : ''}${global.https.portReuse.computed ? ' reuseport' : ''}`]);
+        `${ipPortV4} ssl${domain.https.http2.computed ? ' http2' : ''}${reusePortV4 ? ' reuseport' : ''}`]);
 
     // HTTP/3
     if (domain.https.http3.computed)
-        config.push(['listen',
-            `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}443 http3`]);
+        config.push(['listen', `${ipPortV4} http3`]);
 
     // v6
-    if (domain.server.listenIpv6.computed)
-        config.push(['listen',
-            `[${domain.server.listenIpv6.computed}]:443 ssl${domain.https.http2.computed ? ' http2' : ''}${global.https.portReuse.computed ? ' reuseport' : ''}`]);
+    if (domain.server.listenIpv6.computed) {
+        // Check if reuseport needs to be set
+        const ipPortV6 = `[${domain.server.listenIpv6.computed}]:443`;
+        const reusePortV6 = global.https.portReuse.computed && !ipPortPairs.has(ipPortV6);
+        if (reusePortV6) ipPortPairs.add(ipPortV6);
 
-    // v6 HTTP/3
-    if (domain.server.listenIpv6.computed && domain.https.http3.computed)
+        // HTTPS
         config.push(['listen',
-            `[${domain.server.listenIpv6.computed}]:443 http3`]);
+            `${ipPortV6} ssl${domain.https.http2.computed ? ' http2' : ''}${reusePortV6 ? ' reuseport' : ''}`]);
+
+        // HTTP/3
+        if (domain.https.http3.computed)
+            config.push(['listen', `${ipPortV6} http3`]);
+    }
 
     return config;
 };
 
-const httpListen = domain => {
+const httpListen = (domain, global, ipPortPairs) => {
     const config = [];
 
-    // Not HTTPS
-    config.push(['listen',
-        `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}80`]);
+    // Check if reuseport needs to be set
+    const ipPortV4 = `${domain.server.listenIpv4.computed === '*' ? '' : `${domain.server.listenIpv4.computed}:`}80`;
+    const reusePortV4 = global.https.portReuse.computed && !ipPortPairs.has(ipPortV4);
+    if (reusePortV4) ipPortPairs.add(ipPortV4);
+
+    // v4
+    config.push(['listen', `${ipPortV4}${reusePortV4 ? ' reuseport' : ''}`]);
 
     // v6
-    if (domain.server.listenIpv6.computed)
-        config.push(['listen', `[${domain.server.listenIpv6.computed}]:80`]);
+    if (domain.server.listenIpv6.computed) {
+        // Check if reuseport needs to be set
+        const ipPortV6 = `[${domain.server.listenIpv6.computed}]:80`;
+        const reusePortV6 = global.https.portReuse.computed && !ipPortPairs.has(ipPortV6);
+        if (reusePortV6) ipPortPairs.add(ipPortV6);
+
+        config.push(['listen', `${ipPortV6}${reusePortV6 ? ' reuseport' : ''}`]);
+    }
 
     return config;
 };
 
-const listenConfig = (domain, global) => {
-    if (domain.https.https.computed) return httpsListen(domain, global);
-    return httpListen(domain);
+const listenConfig = (domain, global, ipPortPairs) => {
+    if (domain.https.https.computed) return httpsListen(domain, global, ipPortPairs);
+    return httpListen(domain, global, ipPortPairs);
 };
 
-
-const httpRedirectConfig = (domain, global, domainName, redirectDomain) => {
+const httpRedirectConfig = (domain, global, ipPortPairs, domainName, redirectDomain) => {
     // Build the server config on its own before adding it to the parent config
     const config = [];
 
-    config.push(...httpListen(domain));
+    config.push(...httpListen(domain, global, ipPortPairs));
     config.push(['server_name', domainName]);
 
     if (domain.https.certType.computed === 'letsEncrypt') {
@@ -130,7 +149,7 @@ const httpRedirectConfig = (domain, global, domainName, redirectDomain) => {
     return config;
 };
 
-export default (domain, domains, global) => {
+export default (domain, domains, global, ipPortPairs) => {
     // Use kv so we can use the same key multiple times
     const config = [];
 
@@ -138,10 +157,12 @@ export default (domain, domains, global) => {
     const serverConfig = [];
 
     // Not HTTPS or not force HTTPS
-    if (!domain.https.https.computed || !domain.https.forceHttps.computed) serverConfig.push(...httpListen(domain));
+    if (!domain.https.https.computed || !domain.https.forceHttps.computed)
+        serverConfig.push(...httpListen(domain, global, ipPortPairs));
 
     // HTTPS
-    if (domain.https.https.computed) serverConfig.push(...httpsListen(domain, global));
+    if (domain.https.https.computed)
+        serverConfig.push(...httpsListen(domain, global, ipPortPairs));
 
     serverConfig.push(['server_name',
         `${domain.server.wwwSubdomain.computed ? 'www.' : ''}${domain.server.domain.computed}`]);
@@ -340,7 +361,7 @@ export default (domain, domains, global) => {
         // Build the server config on its own before adding it to the parent config
         const cdnConfig = [];
 
-        cdnConfig.push(...listenConfig(domain, global));
+        cdnConfig.push(...listenConfig(domain, global, ipPortPairs));
         cdnConfig.push(['server_name', `cdn.${domain.server.domain.computed}`]);
         cdnConfig.push(['root', `${domain.server.path.computed}${domain.server.documentRoot.computed}`]);
 
@@ -383,7 +404,7 @@ export default (domain, domains, global) => {
         // Build the server config on its own before adding it to the parent config
         const redirectConfig = [];
 
-        redirectConfig.push(...listenConfig(domain, global));
+        redirectConfig.push(...listenConfig(domain, global, ipPortPairs));
         redirectConfig.push(['server_name',
             `${domain.server.wwwSubdomain.computed ? '' : '*'}.${domain.server.domain.computed}`]);
 
@@ -403,17 +424,21 @@ export default (domain, domains, global) => {
         // Add the redirect config to the parent config now its built
         config.push(['# HTTP redirect', '']);
         if (domain.server.wwwSubdomain.computed && !domain.server.redirectSubdomains.computed) {
-            config.push(['server', httpRedirectConfig(domain, global, domain.server.domain.computed,
+            config.push(['server', httpRedirectConfig(domain, global, ipPortPairs,
+                domain.server.domain.computed, `www.${domain.server.domain.computed}`)]);
+            config.push(['server', httpRedirectConfig(domain, global, ipPortPairs,
                 `www.${domain.server.domain.computed}`)]);
-            config.push(['server', httpRedirectConfig(domain, global, `www.${domain.server.domain.computed}`)]);
         } else if (!domain.server.wwwSubdomain.computed && !domain.server.redirectSubdomains.computed) {
-            config.push(['server', httpRedirectConfig(domain, global, domain.server.domain.computed)]);
+            config.push(['server', httpRedirectConfig(domain, global, ipPortPairs,
+                domain.server.domain.computed)]);
         }
         if (domain.server.cdnSubdomain.computed) {
-            config.push(['server', httpRedirectConfig(domain, global, `cdn.${domain.server.domain.computed}`)]);
+            config.push(['server', httpRedirectConfig(domain, global, ipPortPairs,
+                `cdn.${domain.server.domain.computed}`)]);
         }
         if (domain.server.redirectSubdomains.computed) {
-            config.push(['server', httpRedirectConfig(domain, global, `.${domain.server.domain.computed}`,
+            config.push(['server', httpRedirectConfig(domain, global, ipPortPairs,
+                `.${domain.server.domain.computed}`,
                 `${domain.server.wwwSubdomain.computed ? 'www.' : '' }${domain.server.domain.computed}`)]);
         }
     }

--- a/src/nginxconfig/generators/index.js
+++ b/src/nginxconfig/generators/index.js
@@ -57,8 +57,10 @@ export default (domains, global) => {
     // Modularised configs
     if (global.tools.modularizedStructure.computed) {
         // Domain config
+        const sitesDir = `sites-${global.tools.symlinkVhost.computed ? 'available' : 'enabled'}`;
+        const ipPortPairs = new Set();
         for (const domain of domains) {
-            files[`sites-${global.tools.symlinkVhost.computed ? 'available' : 'enabled'}/${domain.server.domain.computed}.conf`] = toConf(websiteConf(domain, domains, global));
+            files[`${sitesDir}/${domain.server.domain.computed}.conf`] = toConf(websiteConf(domain, domains, global, ipPortPairs));
         }
 
         // Let's encrypt

--- a/src/nginxconfig/i18n/en/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/en/templates/domain_sections/https.js
@@ -32,8 +32,6 @@ export default {
     enableHttp2Connections: `${common.enable} ${common.http}/2 connections`,
     http3: `${common.http}/3`,
     enableHttp3Connections: `${common.enable} ${common.http}/3 connections`,
-    portReuse: 'Reuseport',
-    enableReuseOfPort: `${common.enable} reuseport to generate a listening socket per worker`,
     forceHttps: `Force ${common.https}`,
     hsts: 'HSTS',
     enableStrictTransportSecurity: `${common.enable} Strict Transport Security, requiring HTTPS connections`,

--- a/src/nginxconfig/i18n/en/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/en/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/https.js
@@ -33,6 +33,8 @@ const ipv6 = 'IPv6';
 export default {
     sslProfile: `${common.ssl} Profile`,
     httpsMustBeEnabledOnOneSite: `${common.https} must be enabled on at least one site to configure global ${common.https} settings.`,
+    portReuse: 'Reuseport',
+    enableReuseOfPort: `${common.enable} reuseport to generate a listening socket per worker`,
     ocspDnsResolvers: 'OCSP DNS Resolvers',
     cloudflareResolver: 'Cloudflare Resolver',
     googlePublicDns: 'Google Public DNS',

--- a/src/nginxconfig/i18n/fr/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/fr/templates/domain_sections/https.js
@@ -32,8 +32,6 @@ export default {
     enableHttp2Connections: `${common.enable} les connexions ${common.http}/2`,
     http3: `${common.http}/3`,
     enableHttp3Connections: `${common.enable} les connexions ${common.http}/3`,
-    portReuse: 'Reuseport', // TODO: translate
-    enableReuseOfPort: `${common.enable} reuseport to generate a listening socket per worker`, // TODO: translate
     forceHttps: `Forcer ${common.https}`,
     hsts: 'HSTS',
     enableStrictTransportSecurity: `${common.enable} Strict Transport Security, exigeant HTTPS`,

--- a/src/nginxconfig/i18n/fr/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/fr/templates/global_sections/https.js
@@ -33,6 +33,8 @@ const ipv6 = 'IPv6';
 export default {
     sslProfile: `Profil ${common.ssl}`,
     httpsMustBeEnabledOnOneSite: `${common.https} doit être activé sur au moins un site pour configurer les paramètres ${common.https} globaux.`,
+    portReuse: 'Reuseport', // TODO: translate
+    enableReuseOfPort: `${common.enable} reuseport to generate a listening socket per worker`, // TODO: translate
     ocspDnsResolvers: 'Résolveur DNS OCSP',
     cloudflareResolver: 'Résolveur Cloudflare',
     googlePublicDns: 'Google Public DNS',

--- a/src/nginxconfig/i18n/pl/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/pl/templates/domain_sections/https.js
@@ -32,8 +32,6 @@ export default {
     enableHttp2Connections: `${common.enable} połączenia ${common.http}/2`,
     http3: `${common.http}/3`,
     enableHttp3Connections: `${common.enable} połączenia ${common.http}/3`,
-    portReuse: 'Reuseport',
-    enableReuseOfPort: `${common.enable} reuseport aby generować listening socket per worker`,
     forceHttps: `Wymuś ${common.https}`,
     hsts: 'HSTS',
     enableStrictTransportSecurity: `${common.enable} Strict Transport Security, wymaga połaczenia HTTPS`,

--- a/src/nginxconfig/i18n/pl/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/pl/templates/global_sections/https.js
@@ -33,6 +33,8 @@ const ipv6 = 'IPv6';
 export default {
     sslProfile: `Profil ${common.ssl}`,
     httpsMustBeEnabledOnOneSite: `${common.https} musi być włączony na conajmniej jednej stronie, aby móc zastosować globalną konfigurację ${common.https}.`,
+    portReuse: 'Reuseport',
+    enableReuseOfPort: `${common.enable} reuseport aby generować listening socket per worker`,
     ocspDnsResolvers: 'OCSP DNS Resolvers',
     cloudflareResolver: 'Cloudflare Resolver',
     googlePublicDns: 'Google Public DNS',

--- a/src/nginxconfig/i18n/pt-br/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/pt-br/templates/domain_sections/https.js
@@ -32,8 +32,6 @@ export default {
     enableHttp2Connections: `${common.enable} conexões ${common.http}/2`,
     http3: `${common.http}/3`,
     enableHttp3Connections: `${common.enable} conexões ${common.http}/3`,
-    portReuse: 'Reuseport', // TODO: translate
-    enableReuseOfPort: `${common.enable} reuseport to generate a listening socket per worker`, // TODO: translate
     forceHttps: `Forçar ${common.https}`,
     hsts: 'HSTS',
     enableStrictTransportSecurity: `${common.enable} Strict Transport Security, requerendo conexões HTTPS`,

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/https.js
@@ -33,6 +33,8 @@ const ipv6 = 'IPv6';
 export default {
     sslProfile: `Perfil ${common.ssl}`,
     httpsMustBeEnabledOnOneSite: `O ${common.https} deve estar habilitado em pelo menos um site para definir as configurações globais de ${common.https}.`,
+    portReuse: 'Reuseport', // TODO: translate
+    enableReuseOfPort: `${common.enable} reuseport to generate a listening socket per worker`, // TODO: translate
     ocspDnsResolvers: 'Resolvedores de DNS OCSP',
     cloudflareResolver: 'Resolvedor Cloudflare',
     googlePublicDns: 'DNS público do Google',

--- a/src/nginxconfig/i18n/ru/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/ru/templates/domain_sections/https.js
@@ -32,8 +32,6 @@ export default {
     enableHttp2Connections: `${common.enable} ${common.http}/2 соединения`,
     http3: `${common.http}/3`,
     enableHttp3Connections: `${common.enable} ${common.http}/3 соединения`,
-    portReuse: 'Reuseport', // TODO: translate
-    enableReuseOfPort: `${common.enable} reuseport to generate a listening socket per worker`, // TODO: translate
     forceHttps: `Использовать только ${common.https}`,
     hsts: 'HSTS',
     enableStrictTransportSecurity: `${common.enable} Strict Transport Security, требующая HTTPS соединения`,

--- a/src/nginxconfig/i18n/ru/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/ru/templates/global_sections/https.js
@@ -33,6 +33,8 @@ const ipv6 = 'IPv6';
 export default {
     sslProfile: `${common.ssl} Профиль`,
     httpsMustBeEnabledOnOneSite: `${common.https} должен быть включен хотя бы на одном сайте, чтобы сконфигурировать глобальные ${common.https} настройки.`,
+    portReuse: 'Reuseport', // TODO: translate
+    enableReuseOfPort: `${common.enable} reuseport to generate a listening socket per worker`, // TODO: translate
     ocspDnsResolvers: 'OCSP DNS Преобразователи',
     cloudflareResolver: 'Cloudflare Преобразователь',
     googlePublicDns: 'Публичные Google DNS',

--- a/src/nginxconfig/i18n/zh-cn/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/domain_sections/https.js
@@ -32,8 +32,6 @@ export default {
     enableHttp2Connections: `${common.enable} ${common.http}/2 连接`,
     http3: `${common.http}/3`,
     enableHttp3Connections: `${common.enable} ${common.http}/3 连接`,
-    portReuse: '端口重用',
-    enableReuseOfPort: `${common.enable} 重用端口 为每个 NGINX Worker 单独生成一个监听套接字`,
     forceHttps: `强制 ${common.https}`,
     hsts: 'HSTS',
     enableStrictTransportSecurity: `${common.enable}HSTS（强制客户端、浏览器等使用 HTTPS 与服务器创建链接），需要HTTPS连接`,

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/https.js
@@ -33,6 +33,8 @@ const ipv6 = 'IPv6';
 export default {
     sslProfile: `${common.ssl}配置`,
     httpsMustBeEnabledOnOneSite: `必须在至少一个站点上启用${common.https}才能配置全局${common.https}设置。`,
+    portReuse: '端口重用',
+    enableReuseOfPort: `${common.enable} 重用端口 为每个 NGINX Worker 单独生成一个监听套接字`,
     ocspDnsResolvers: 'OCSP DNS解析器',
     cloudflareResolver: 'Cloudflare解析器',
     googlePublicDns: '谷歌公共DNS',

--- a/src/nginxconfig/i18n/zh-tw/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/domain_sections/https.js
@@ -32,8 +32,6 @@ export default {
     enableHttp2Connections: `${common.enable} ${common.http}/2 連接`,
     http3: `${common.http}/3`,
     enableHttp3Connections: `${common.enable} ${common.http}/3 連接`,
-    portReuse: '端口複用',
-    enableReuseOfPort: `${common.enable} 端口複用來為每個worker生成監聽套接字`,
     forceHttps: `強制 ${common.https}`,
     hsts: 'HSTS',
     enableStrictTransportSecurity: `${common.enable}HSTS（強制用戶端、瀏覽器等使用HTTPS與服務器創建連結），需要HTTPS連接`,

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/https.js
@@ -33,6 +33,8 @@ const ipv6 = 'IPv6';
 export default {
     sslProfile: `${common.ssl}配寘`,
     httpsMustBeEnabledOnOneSite: `必須在至少一個網站上啟用${common.https}才能配寘全域${common.https}設定。`,
+    portReuse: '端口複用',
+    enableReuseOfPort: `${common.enable} 端口複用來為每個worker生成監聽套接字`,
     ocspDnsResolvers: 'OCSP DNS解析器',
     cloudflareResolver: 'Cloudflare解析器',
     googlePublicDns: '穀歌公共DNS',

--- a/src/nginxconfig/templates/domain_sections/https.vue
+++ b/src/nginxconfig/templates/domain_sections/https.vue
@@ -96,24 +96,6 @@ THE SOFTWARE.
             </div>
         </div>
 
-        <div v-if="portReuseEnabled" class="field is-horizontal">
-            <div class="field-label">
-                <label class="label">{{ $t('templates.domainSections.https.portReuse') }}</label>
-            </div>
-            <div class="field-body">
-                <div class="field">
-                    <div :class="`control${portReuseChanged ? ' is-changed' : ''}`">
-                        <div class="checkbox">
-                            <PrettyCheck v-model="portReuse" class="p-default p-curve p-fill p-icon">
-                                <i slot="extra" class="icon fas fa-check"></i>
-                                {{ $t('templates.domainSections.https.enableReuseOfPort') }}
-                            </PrettyCheck>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
         <div v-if="forceHttpsEnabled" class="field is-horizontal">
             <div class="field-label">
                 <label class="label">{{ $t('templates.domainSections.https.forceHttps') }}</label>
@@ -260,10 +242,6 @@ THE SOFTWARE.
             enabled: true,
         },
         http3: {
-            default: false,
-            enabled: true,
-        },
-        portReuse: {
             default: false,
             enabled: true,
         },

--- a/src/nginxconfig/templates/domain_sections/https.vue
+++ b/src/nginxconfig/templates/domain_sections/https.vue
@@ -264,8 +264,8 @@ THE SOFTWARE.
             enabled: true,
         },
         portReuse: {
-            default: true,
-            enabled: false,
+            default: false,
+            enabled: true,
         },
         forceHttps: {
             default: true,
@@ -355,19 +355,6 @@ THE SOFTWARE.
                         this.$props.data.hsts.computed = false;
                         this.$props.data.certType.enabled = false;
                         this.$props.data.certType.computed = '';
-                    }
-                },
-                deep: true,
-            },
-            // Only allow port reuse when HTTP/3 is enabled first
-            '$props.data.http3': {
-                handler(data) {
-                    if (data.computed) {
-                        this.$props.data.portReuse.enabled = true;
-                        this.$props.data.portReuse.computed = this.$props.data.portReuse.value;
-                    } else {
-                        this.$props.data.portReuse.enabled = false;
-                        this.$props.data.portReuse.computed = false;
                     }
                 },
                 deep: true,

--- a/src/nginxconfig/templates/global_sections/https.vue
+++ b/src/nginxconfig/templates/global_sections/https.vue
@@ -66,6 +66,24 @@ THE SOFTWARE.
 
             <div class="field is-horizontal is-aligned-top">
                 <div class="field-label">
+                    <label class="label">{{ $t('templates.globalSections.https.portReuse') }}</label>
+                </div>
+                <div class="field-body">
+                    <div class="field">
+                        <div :class="`control${portReuseChanged ? ' is-changed' : ''}`">
+                            <div class="checkbox">
+                                <PrettyCheck v-model="portReuse" class="p-default p-curve p-fill p-icon">
+                                    <i slot="extra" class="icon fas fa-check"></i>
+                                    {{ $t('templates.globalSections.https.enableReuseOfPort') }}
+                                </PrettyCheck>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="field is-horizontal is-aligned-top">
+                <div class="field-label">
                     <label class="label">{{ $t('templates.globalSections.https.ocspDnsResolvers') }}</label>
                 </div>
                 <div class="field-body">
@@ -246,6 +264,10 @@ THE SOFTWARE.
                 intermediate: 'templates.globalSections.https.mozillaIntermediate', // i18n key
                 old: 'templates.globalSections.https.mozillaOld', // i18n key
             },
+            enabled: true,
+        },
+        portReuse: {
+            default: false,
             enabled: true,
         },
         ocspCloudflare: {

--- a/src/nginxconfig/templates/global_sections/https.vue
+++ b/src/nginxconfig/templates/global_sections/https.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -26,6 +26,24 @@ THE SOFTWARE.
 
 <template>
     <div>
+        <div class="field is-horizontal">
+            <div class="field-label">
+                <label class="label">{{ $t('templates.globalSections.https.portReuse') }}</label>
+            </div>
+            <div class="field-body">
+                <div class="field">
+                    <div :class="`control${portReuseChanged ? ' is-changed' : ''}`">
+                        <div class="checkbox">
+                            <PrettyCheck v-model="portReuse" class="p-default p-curve p-fill p-icon">
+                                <i slot="extra" class="icon fas fa-check"></i>
+                                {{ $t('templates.globalSections.https.enableReuseOfPort') }}
+                            </PrettyCheck>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div v-if="!sslProfileEnabled" class="field is-horizontal is-aligned-top">
             <div class="field-label">
                 <label class="label">{{ $t('templates.globalSections.https.sslProfile') }}</label>
@@ -58,24 +76,6 @@ THE SOFTWARE.
                                         {{ $t(name) }}
                                     </PrettyRadio>
                                 </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="field is-horizontal is-aligned-top">
-                <div class="field-label">
-                    <label class="label">{{ $t('templates.globalSections.https.portReuse') }}</label>
-                </div>
-                <div class="field-body">
-                    <div class="field">
-                        <div :class="`control${portReuseChanged ? ' is-changed' : ''}`">
-                            <div class="checkbox">
-                                <PrettyCheck v-model="portReuse" class="p-default p-curve p-fill p-icon">
-                                    <i slot="extra" class="icon fas fa-check"></i>
-                                    {{ $t('templates.globalSections.https.enableReuseOfPort') }}
-                                </PrettyCheck>
                             </div>
                         </div>
                     </div>
@@ -257,6 +257,10 @@ THE SOFTWARE.
     };
 
     const defaults = {
+        portReuse: {
+            default: false,
+            enabled: true,
+        },
         sslProfile: {
             default: 'intermediate',
             options: {
@@ -264,10 +268,6 @@ THE SOFTWARE.
                 intermediate: 'templates.globalSections.https.mozillaIntermediate', // i18n key
                 old: 'templates.globalSections.https.mozillaOld', // i18n key
             },
-            enabled: true,
-        },
-        portReuse: {
-            default: false,
             enabled: true,
         },
         ocspCloudflare: {


### PR DESCRIPTION
## Type of Change
- **Tool Source:**
  - generators/conf/website.conf.js
  - templates/domain_sections/https.vue 

## What issue does this relate to?
N/A

### What should this PR do?
This PR will enable reuse port to be toggled on for HTTP/1.1 and HTTP/2. This is not a HTTP/3 only feature and can have major benefits on HTTP/1.1 and HTTP/2 (Benchmark here: https://www.nginx.com/blog/socket-sharding-nginx-release-1-9-1/).

HTTP/3 needs a different listener (Since UDP rather than TCP) however, it still listens to the same IP:port and the socket options should only be on one pair. Due to this, I moved the reuseport over to the HTTP/1.1 and HTTP/2 listen directive. Even if HTTP/2 isn't enabled and HTTP/3 is, the option will be there.

### What are the acceptance criteria?
* Users can toggle reuse port
* It is added to nginx listen directives (only once per ip:port pair)
* The `reuseport` should be on the HTTP/1.1 / HTTP/2 listen directive even if HTTP/3 is enabled

Default config:
![image](https://user-images.githubusercontent.com/8492901/123310012-89f16a80-d51d-11eb-9732-56ece5e83498.png)
![image](https://user-images.githubusercontent.com/8492901/123310048-937ad280-d51d-11eb-811d-150738407fe3.png)

Enabled:
![image](https://user-images.githubusercontent.com/8492901/123509924-4d825380-d670-11eb-87ac-d6c1c5d89349.png)
![image](https://user-images.githubusercontent.com/8492901/123310098-a2fa1b80-d51d-11eb-9cfc-6abbdc6d5ee7.png)

Enabled with HTTP/3 enabled too:
![image](https://user-images.githubusercontent.com/8492901/123311543-35e78580-d51f-11eb-849e-aeca36909d60.png)

Enabled on only one pair:
![image](https://user-images.githubusercontent.com/8492901/123509932-63901400-d670-11eb-8cb7-82df825a1fa7.png)
