### PR TITLE
add acme.sh and rename certbot to ssl_cert

### DIFF
--- a/src/nginxconfig/i18n/en/templates/setup_sections/index.js
+++ b/src/nginxconfig/i18n/en/templates/setup_sections/index.js
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import certbot from './certbot';
+import ssl_cert from './ssl_cert';
 import download from './download';
 import goLive from './go_live';
 import ssl from './ssl';
 
-export default { certbot, download, goLive, ssl };
+export default { ssl_cert, download, goLive, ssl };

--- a/src/nginxconfig/i18n/en/templates/setup_sections/ssl_cert.js
+++ b/src/nginxconfig/i18n/en/templates/setup_sections/ssl_cert.js
@@ -26,14 +26,14 @@ THE SOFTWARE.
 
 import common from '../../common';
 
-const certbot = 'Certbot';
+const sslCert = 'SSL cert';
 
 export default {
     commentOutSslDirectivesInConfiguration: `Comment out ${common.ssl} related directives in the configuration:`,
     reloadYourNginxServer: `Reload your ${common.nginx} server:`,
-    obtainSslCertificatesFromLetsEncrypt: `Obtain ${common.ssl} certificates from ${common.letsEncrypt} using ${certbot}:`,
+    obtainSslCertificatesFromLetsEncrypt: `Obtain ${common.ssl} certificates from ${common.letsEncrypt} using ${sslCert} method perferred: CertBot or Acme.sh:`,
     uncommentSslDirectivesInConfiguration: `Uncomment ${common.ssl} related directives in the configuration:`,
-    configureCertbotToReloadNginxOnCertificateRenewal: `Configure ${certbot} to reload ${common.nginx} when it successfully renews certificates:`,
-    certbotDoesNotNeedToBeSetupForYourConfiguration: `${certbot} does not need to be set up for your ${common.nginx} configuration.`,
-    certbot,
+    configureSslCertToReloadNginxOnCertificateRenewal: `Configure ${sslCert} method to reload ${common.nginx} when it successfully renews certificates:`,
+    sslCertDoesNotNeedToBeSetupForYourConfiguration: `${sslCert} method does not need to be set up for your ${common.nginx} configuration.`,
+    sslCert,
 };

--- a/src/nginxconfig/templates/setup_sections/index.js
+++ b/src/nginxconfig/templates/setup_sections/index.js
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 import Download from './download';
 import SSL from './ssl';
-import Certbot from './certbot';
+import SLLCert from './ssl_cert';
 import GoLive from './go_live';
 
-export default [ Download, SSL, Certbot, GoLive ];
+export default [ Download, SSL, SLLCert, GoLive ];


### PR DESCRIPTION
## Type of Change

Something Else: Added acme.sh commands to steps 3 & 6 as an alternative option to certbot for EN flow (If good international version will be committed afterwards)

## What issue does this relate to?
resolves #277 

### What should this PR do?
* Add acme.sh to steps 3 & 6 of ssl certification 
* Rename all instances of certbot to sslCert or ssl_cert in EN version.

### What are the acceptance criteria?
* Acme.sh commands work on local machine
* Added UI elements still make the ssl_cert section look appealing and keep instructions not confusing

![Screenshot 2021-07-01 at 01-23-35 SSD Cloud Server, VPS Server, Simple Cloud Hosting by DigitalOcean](https://user-images.githubusercontent.com/86040306/124092674-f8e22e00-da0b-11eb-9914-6bc0f9394bd7.png)
![Screenshot 2021-07-01 at 01-32-24 NGINXConfig DigitalOcean](https://user-images.githubusercontent.com/86040306/124092798-17e0c000-da0c-11eb-8fa8-79293ebd65fb.png)
