### PR TITLE
Update and fix diffing logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10663,9 +10663,9 @@
       "optional": true
     },
     "files-diff": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/files-diff/-/files-diff-0.0.5.tgz",
-      "integrity": "sha512-0Z/K2aVj19Dxpvl5F5SkINmmnSamMPwSuWh3U7s35ojQ2DzzTvkHjbeuiUgLX8JgyNsV2nk/XAVDangV+Nls3g==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/files-diff/-/files-diff-0.0.6.tgz",
+      "integrity": "sha512-qf03b6nVKD1xqymd00+fFje5ANk71fxGttKu4vq8VcZThCVpipdrXs6oXf4R6e6T4+zPF/3+CmKM3FPCbgFkSg==",
       "requires": {
         "diff": "^5.0.0",
         "escape-html": "^1.0.3",
@@ -17159,7 +17159,7 @@
         "known-css-properties": "^0.3.0",
         "lodash.capitalize": "^4.1.0",
         "lodash.kebabcase": "^4.0.0",
-        "merge": "^1.2.0",
+        "merge": "^2.1.1",
         "path-is-absolute": "^1.0.0",
         "util": "^0.10.3"
       },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "do-bulma": "git+https://github.com/do-community/do-bulma.git",
     "do-vue": "git+https://github.com/do-community/do-vue.git",
     "escape-html": "^1.0.3",
-    "files-diff": "0.0.5",
+    "files-diff": "0.0.6",
     "json-to-pretty-yaml": "^1.2.2",
     "memory-tar-create": "0.0.3",
     "pretty-checkbox-vue": "^1.1.9",

--- a/src/nginxconfig/templates/app.vue
+++ b/src/nginxconfig/templates/app.vue
@@ -347,7 +347,6 @@ THE SOFTWARE.
                         highlightFunction: value => `<mark>${value}</mark>`,
                     });
                     this.$data.confFilesOutput = Object.entries(diffConf).map(([ file, { name, content } ]) => {
-                        console.log(file, name);
                         const diffName = name.filter(x => !x.removed).map(x => x.value).join('');
                         const diffContent = content.filter(x => !x.removed).map(x => x.value).join('');
 


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue: Main app
- **Something else:** Deps

## What issue does this relate to?

N/A

### What should this PR do?

Bumps files-diff library to the latest version, update diffing logic to pass full file path to diff.

### What are the acceptance criteria?

- Changing the config directory in the global NGINX options will show the correct diff in file names.
- Any HTML present in the values of a file that has no diff are still escaped (files-diff upstream change).