### PR TITLE
Improve mobile styling for the presets panel button group

### DIFF
--- a/src/nginxconfig/scss/_panel.scss
+++ b/src/nginxconfig/scss/_panel.scss
@@ -38,7 +38,7 @@ THE SOFTWARE.
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
-      justify-content: space-between;
+      justify-content: start;
     }
 
     .header-group {
@@ -62,7 +62,11 @@ THE SOFTWARE.
       align-items: center;
 
       .button {
+        flex: auto;
         margin: 0 .25rem .5rem;
+      }
+      .button:last-child {
+        flex: 0;
       }
     }
   }

--- a/src/nginxconfig/scss/_panel.scss
+++ b/src/nginxconfig/scss/_panel.scss
@@ -65,6 +65,7 @@ THE SOFTWARE.
         flex: auto;
         margin: 0 .25rem .5rem;
       }
+      
       .button:last-child {
         flex: 0;
       }


### PR DESCRIPTION
This patch fixes the styling for the buttons in the preset panel

Here's how it looks now:
![image](https://user-images.githubusercontent.com/79141224/135347705-6e65d1eb-c022-4f53-9d75-8397527a403b.png)

Compared to before:
![image](https://user-images.githubusercontent.com/79141224/135347751-e190ea73-4be7-43ef-8365-0c00f2dca20e.png)
