### PR TITLE
Add Russian translations for Reuseport

### DIFF
--- a/src/nginxconfig/i18n/ru/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/ru/templates/global_sections/https.js
@@ -33,8 +33,8 @@ const ipv6 = 'IPv6';
 export default {
     sslProfile: `${common.ssl} Профиль`,
     httpsMustBeEnabledOnOneSite: `${common.https} должен быть включен хотя бы на одном сайте, чтобы сконфигурировать глобальные ${common.https} настройки.`,
-    portReuse: 'Reuseport', // TODO: translate
-    enableReuseOfPort: `${common.enable} reuseport to generate a listening socket per worker`, // TODO: translate
+    portReuse: 'Reuseport',
+    enableReuseOfPort: `${common.enable} reuseport чтобы создавать отдельный слушающий сокет для каждого рабочего процесса`,
     ocspDnsResolvers: 'OCSP DNS Преобразователи',
     cloudflareResolver: 'Cloudflare Преобразователь',
     googlePublicDns: 'Публичные Google DNS',


### PR DESCRIPTION
## Type of Change
Added Russian translations for HTTP3 sentences. Please note that "reuseport" term should not be translated. Just like other terms like "OCSP DNS" because "reuseport" is commonly used tech term.
