### PR TITLE
Russian translation updates

### DIFF
--- a/src/nginxconfig/i18n/ru/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/ru/templates/domain_sections/https.js
@@ -40,9 +40,9 @@ export default {
     certificationType: 'Тип сертификации',
     customCertificate: 'Другой сертификат',
     letsEncryptEmail: `${common.letsEncrypt} email`,
-    http3IsANonStandardModule: 'HTTP/3 isn\'t a standard NGINX module, check the ', // TODO: translate
-    http3NginxQuicReadme: 'NGINX QUIC readme', // TODO: translate
-    http3OrThe: ' or the ', // TODO: translate
-    http3CloudflareQuicheProject: 'Cloudflare quiche project', // TODO: translate
-    http3ForBuildingNginxWithHttp3: ' for how to build NGINX with HTTP/3!', // TODO: translate
+    http3IsANonStandardModule: 'HTTP/3 не является стандартным модулем NGINX, ознакомьтесь с ',
+    http3NginxQuicReadme: 'readme NGINX QUIC',
+    http3OrThe: ' или с ',
+    http3CloudflareQuicheProject: 'проектом Cloudflare quiche',
+    http3ForBuildingNginxWithHttp3: ' чтобы узнать как собрать NGINX с HTTP/3!',
 };

--- a/src/nginxconfig/i18n/ru/templates/domain_sections/presets.js
+++ b/src/nginxconfig/i18n/ru/templates/domain_sections/presets.js
@@ -27,7 +27,7 @@ THE SOFTWARE.
 export default {
     presets: 'Пресеты',
     itLooksLikeYouCustomisedTheConfig: 'Похоже, вы уже настроили конфигурацию для этого домена. Выбор нового пресета может привести к сбросу или изменению некоторых настроек, которые Вы настроили ранее.',
-    frontend: 'Фронтэнд',
+    frontend: 'Фронтенд',
     nodeJs: 'Node.js',
     singlePageApplication: 'Одностраничное приложение',
 };

--- a/src/nginxconfig/i18n/ru/templates/footer.js
+++ b/src/nginxconfig/i18n/ru/templates/footer.js
@@ -31,7 +31,7 @@ export default {
     underThe: 'под',
     mit: 'MIT',
     license: 'лицензией!',
-    weWelcomeFeedbackAndContributions: 'Мы приветсвуем обратную связь и поддержку.',
+    weWelcomeFeedbackAndContributions: 'Мы приветствуем обратную связь и поддержку.',
     originallyCreatedBy: 'Начало проекта положил',
     balintSzekeres: 'Bálint Szekeres',
     maintainedBy: 'при поддержке',

--- a/src/nginxconfig/i18n/ru/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/ru/templates/global_sections/https.js
@@ -33,8 +33,8 @@ const ipv6 = 'IPv6';
 export default {
     sslProfile: `${common.ssl} Профиль`,
     httpsMustBeEnabledOnOneSite: `${common.https} должен быть включен хотя бы на одном сайте, чтобы сконфигурировать глобальные ${common.https} настройки.`,
-    portReuse: 'Reuseport', // TODO: translate
-    enableReuseOfPort: `${common.enable} reuseport to generate a listening socket per worker`, // TODO: translate
+    portReuse: 'Reuseport',
+    enableReuseOfPort: `${common.enable} reuseport чтобы создавать отдельный слушающий сокет для каждого рабочего процесса`,
     ocspDnsResolvers: 'OCSP DNS Преобразователи',
     cloudflareResolver: 'Cloudflare Преобразователь',
     googlePublicDns: 'Публичные Google DNS',


### PR DESCRIPTION
## Type of Change
Large Russian translation updates, see #304 #303

- Add Reuseport translation
- Add HTTP/3 translation
- Replace "ФронтЭнд" with commonly used "фронтенд". 