### PR TITLE
Use pre-computed Diffie-Hellman param file instead.

### DIFF
--- a/src/nginxconfig/templates/setup_sections/ssl.vue
+++ b/src/nginxconfig/templates/setup_sections/ssl.vue
@@ -32,7 +32,7 @@ THE SOFTWARE.
                     <span v-html="$t('templates.setupSections.ssl.generateDiffieHellmanKeysByRunningThisCommandOnYourServer')"></span>
                     <br />
                     <BashPrism :key="`${$props.data.global.nginx.nginxConfigDirectory.computed}-${diffieHellmanValue}`"
-                               :cmd="`openssl dhparam -out ${$props.data.global.nginx.nginxConfigDirectory.computed}/dhparam.pem ${diffieHellmanValue}`"
+                               :cmd="`curl https://ssl-config.mozilla.org/ffdhe2048.txt > ${$props.data.global.nginx.nginxConfigDirectory.computed}/dhparam.pem`"
                                @copied="codeCopiedEvent('Generate diffie-hellman keys')"
                     ></BashPrism>
                 </p>


### PR DESCRIPTION
Mozilla recommends using either of the files from RFC 7919 rather than
generating one yourself.

I haven't spun on a local version of this. Having a `Dockerfile` for local testing/development would be nice :)

## Type of Change
- **Something else:** Let's trust Mozilla's recommendations on web security.