### PR TITLE
fix: cloudflare quiche link

### DIFF
--- a/src/nginxconfig/templates/domain_sections/https.vue
+++ b/src/nginxconfig/templates/domain_sections/https.vue
@@ -88,7 +88,7 @@ THE SOFTWARE.
                                 {{ $t('templates.domainSections.https.http3OrThe') }}
                                 <ExternalLink
                                     :text="$t('templates.domainSections.https.http3CloudflareQuicheProject')"
-                                    link="https://github.com/cloudflare/quiche/tree/master/extras/nginx"
+                                    link="https://github.com/cloudflare/quiche/tree/master/nginx"
                                 ></ExternalLink>
                                 {{ $t('templates.domainSections.https.http3ForBuildingNginxWithHttp3') }}
                             </span>


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue

## What issue does this relate to?
Fixes #334

### What should this PR do?
- Update broken link to Cloudflare quiche's GitHub repository. 