### PR TITLE
Fix index.html fallback

### DIFF
--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -235,7 +235,12 @@ export default (domain, domains, global, ipPortPairs) => {
     // index.php
     if (domain.routing.index.computed === 'index.php') {
         serverConfig.push(['# index.php', '']);
-        serverConfig.push(['index', 'index.php']);
+        serverConfig.push(['index', 'index.php' + domain.routing.fallbackHtml.computed ? ' index.html' : '']);
+    }
+
+    if (domain.routing.index.computed === 'index.html') {
+        serverConfig.push(['# index.php', '']);
+        serverConfig.push(['index', 'index.html' + domain.routing.fallbackPhp.computed ? ' index.php' : '']);
     }
 
     // Fallback index.html or index.php


### PR DESCRIPTION
If an index.html was added to a root of a directory it would not show without adding /index.html after it, the fallback options do not work. This fixes that issue.
