### PR TITLE
Allow websockets in default CSP

### DIFF
--- a/src/nginxconfig/templates/global_sections/security.vue
+++ b/src/nginxconfig/templates/global_sections/security.vue
@@ -180,7 +180,7 @@ THE SOFTWARE.
             enabled: true,
         },
         contentSecurityPolicy: {
-            default: 'default-src \'self\' http: https: data: blob: \'unsafe-inline\'; frame-ancestors \'self\';',
+            default: 'default-src \'self\' http: https: ws: wss: data: blob: \'unsafe-inline\'; frame-ancestors \'self\';',
             enabled: true,
         },
         permissionsPolicy: {


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue (global security)

## What issue does this relate to?

N/A

### What should this PR do?

Updates the default CSP value to allow insecure and secure WebSockets, alongside the existing insecure and secure HTTP resources.

### What are the acceptance criteria?

WebSockets are permitted under the default CSP value in the tool.