### PR TITLE
Add PHP 8.1 FPM socket option

### DIFF
--- a/src/nginxconfig/i18n/de/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2022 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -50,6 +50,7 @@ export default {
     php73Socket: '7.3 Socket',
     php74Socket: '7.4 Socket',
     php80Socket: '8.0 Socket',
+    php81Socket: '8.1 Socket',
     phpSocket: 'PHP Socket',
     custom: 'Benutzerdefiniert',
     disabled: 'Deaktiviert',

--- a/src/nginxconfig/i18n/en/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/en/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2022 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -50,6 +50,7 @@ export default {
     php73Socket: '7.3 socket',
     php74Socket: '7.4 socket',
     php80Socket: '8.0 socket',
+    php81Socket: '8.1 socket',
     phpSocket: 'PHP socket',
     custom: 'Custom',
     disabled: 'Disabled',

--- a/src/nginxconfig/i18n/es/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/es/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2022 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -50,6 +50,7 @@ export default {
     php73Socket: '7.3 socket',
     php74Socket: '7.4 socket',
     php80Socket: '8.0 socket',
+    php81Socket: '8.1 socket',
     phpSocket: 'PHP socket',
     custom: 'Personalizado',
     disabled: 'Desactivado',

--- a/src/nginxconfig/i18n/fr/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/fr/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2022 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -50,6 +50,7 @@ export default {
     php73Socket: 'Socket 7.3',
     php74Socket: 'Socket 7.4',
     php80Socket: 'Socket 8.0',
+    php81Socket: 'Socket 8.1',
     phpSocket: 'Socket PHP',
     custom: 'Custom',
     disabled: 'Désactivé',

--- a/src/nginxconfig/i18n/pl/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/pl/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2022 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -50,6 +50,7 @@ export default {
     php73Socket: '7.3 socket',
     php74Socket: '7.4 socket',
     php80Socket: '8.0 socket',
+    php81Socket: '8.1 socket',
     phpSocket: 'PHP socket',
     custom: 'Własny',
     disabled: 'Wyłączony',

--- a/src/nginxconfig/i18n/pt-br/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/pt-br/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2022 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -50,6 +50,7 @@ export default {
     php73Socket: 'Socket 7.3',
     php74Socket: 'Socket 7.4',
     php80Socket: 'Socket 8.0',
+    php81Socket: 'Socket 8.1',
     phpSocket: 'Socket PHP',
     custom: 'Custom', // TODO: translate
     disabled: 'Desabilitado',

--- a/src/nginxconfig/i18n/ru/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/ru/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2022 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -50,6 +50,7 @@ export default {
     php73Socket: '7.3 сокет',
     php74Socket: '7.4 сокет',
     php80Socket: '8.0 сокет',
+    php81Socket: '8.1 сокет',
     phpSocket: 'PHP сокет',
     custom: 'Другой',
     disabled: 'Выключено',

--- a/src/nginxconfig/i18n/zh-cn/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2022 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -50,6 +50,7 @@ export default {
     php73Socket: '7.3 socket',
     php74Socket: '7.4 socket',
     php80Socket: '8.0 socket',
+    php81Socket: '8.1 socket',
     phpSocket: 'PHP socket',
     custom: '自定义',
     disabled: '禁用',

--- a/src/nginxconfig/i18n/zh-tw/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2022 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -50,6 +50,7 @@ export default {
     php73Socket: '7.3 socket',
     php74Socket: '7.4 socket',
     php80Socket: '8.0 socket',
+    php81Socket: '8.1 socket',
     phpSocket: 'PHP socket',
     custom: '自定義',
     disabled: '停用',

--- a/src/nginxconfig/templates/domain_sections/php.vue
+++ b/src/nginxconfig/templates/domain_sections/php.vue
@@ -204,6 +204,7 @@ THE SOFTWARE.
         '/var/run/php/php7.3-fpm.sock': 'templates.domainSections.php.php73Socket',
         '/var/run/php/php7.4-fpm.sock': 'templates.domainSections.php.php74Socket',
         '/var/run/php/php8.0-fpm.sock': 'templates.domainSections.php.php80Socket',
+        '/var/run/php/php8.1-fpm.sock': 'templates.domainSections.php.php81Socket',
         '/var/run/php/php-fpm.sock': 'templates.domainSections.php.phpSocket',
         'custom': 'templates.domainSections.php.custom',
     };


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue (domain PHP)

## What issue does this relate to?

Resolves #344

### What should this PR do?

Adds an option for the specific FPM socket for PHP 8.1

### What are the acceptance criteria?

PHP 8.1 is available in the PHP dropdown.