### PR TITLE
limit_req and Wordpress-specific rules break wp-login.php issue #350 fix

### DIFF
--- a/src/nginxconfig/generators/conf/wordpress.conf.js
+++ b/src/nginxconfig/generators/conf/wordpress.conf.js
@@ -60,6 +60,7 @@ export default global => {
         config['location = /wp-login.php'] = {
             limit_req: 'zone=login burst=2 nodelay',
             include: 'nginxconfig.io/php_fastcgi.conf',
+            fastcgi_pass: 'unix:/run/php/php7.4-fpm.sock',
         };
     }
 


### PR DESCRIPTION
## Type of Change
Changes to fix wordpress-specific rules break wp-login.php

- **Build Scripts:** <!-- Scripts relating to building, testing or CI -->
- **Tool Source:** <!-- Which part of the tool source? Vue, JS, SCSS? -->
- **Something else:** <!-- Say what it is, here! -->

## What issue does this relate to?
<!-- Use a GitHub keyword ('resolves #xx', 'fixes #xx', 'closes #xx') to automatically close the relevant issue. -->
Resolves #350

### What should this PR do?
PR will fix the issue of adding
```
## WordPress: throttle wp-login.php
location ~ /wp-login.php {
    limit_req zone=login burst=20 nodelay;
    include   nginxconfig.io/php_fastcgi.conf;
    fastcgi_pass unix:/run/php/php7.4-fpm.sock;
}
```

### What are the acceptance criteria?
+ Check it successfully adds required changes in wordpress.conf
<!-- If there are UI changes, include before and after screenshots in a table for comparison. -->

### Screenshots
<img width="708" alt="Screenshot 2022-05-23 at 2 55 57 AM" src="https://user-images.githubusercontent.com/29687692/169716552-25c937fb-0853-4c84-a32b-a3fa7b1789d2.png">
<img width="701" alt="Screenshot 2022-05-23 at 2 56 10 AM" src="https://user-images.githubusercontent.com/29687692/169716554-5927418d-1d3b-4b17-aded-ddc8b07a32e1.png">
7692/169716497-faedf4ce-5468-4fc7-803a-9ac4595ed10b.png">
<img width="1422" alt="Screenshot 2022-05-23 at 2 54 32 AM" src="https://user-images.githubusercontent.com/29687692/169716570-3e7a5a3d-0908-412a-bf91-b8f06141122c.png">
