### PR TITLE
wordpress xmlrpc settings

### DIFF
--- a/src/nginxconfig/generators/conf/wordpress.conf.js
+++ b/src/nginxconfig/generators/conf/wordpress.conf.js
@@ -54,9 +54,16 @@ export default (global, domain) => {
     };
 
     config['# WordPress: deny general stuff'] = '';
-    config['location ~* ^/(?:xmlrpc\\.php|wp-links-opml\\.php|wp-config\\.php|wp-config-sample\\.php|readme\\.html|license\\.txt)$'] = {
+    config['location ~* ^/(?:wp-links-opml\\.php|wp-config\\.php|wp-config-sample\\.php|readme\\.html|license\\.txt)$'] = {
         deny: 'all',
     };
+
+    if(global.security.wpDisableXmlrpc.computed){
+        config["# Wordpress: deny xmlrpc, required for mobile and desktop apps"] = ''
+        config['location ~* ^/(?:xmlrpc\\.php)$'] = {
+            deny:'all'
+        }
+    }
 
     if (global.security.limitReq.computed) {
         config['# WordPress: throttle wp-login.php'] = '';

--- a/src/nginxconfig/templates/global_sections/security.vue
+++ b/src/nginxconfig/templates/global_sections/security.vue
@@ -123,6 +123,23 @@ THE SOFTWARE.
 
         <div class="field is-horizontal">
             <div class="field-label">
+                <label class="label">disable xmlrc</label>
+            </div>
+            <div class="field-body">
+                <div class="field">
+                    <div :class="`control${wpDisableXmlrpc ? ' is-changed' : ''}`">
+                        <div class="checkbox">
+                            <PrettyCheck v-model="wpDisableXmlrpc" class="p-default p-curve p-fill p-icon">
+                                {{ $t('common.enable') }}
+                            </PrettyCheck>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="field is-horizontal">
+            <div class="field-label">
                 <label class="label">security.txt</label>
             </div>
             <div class="field-body">
@@ -189,6 +206,10 @@ THE SOFTWARE.
         },
         serverTokens: {
             default: false,
+            enabled: true,
+        },
+        wpDisableXmlrpc:{
+            default: true,
             enabled: true,
         },
         limitReq: {

--- a/src/nginxconfig/util/angular_backwards_compatibility.js
+++ b/src/nginxconfig/util/angular_backwards_compatibility.js
@@ -39,6 +39,7 @@ const globalMap = {
     content_security_policy:    ['security', 'contentSecurityPolicy'],
     server_tokens:              ['security', 'serverTokens', oldBool],
     limit_req:                  ['security', 'limitReq', oldBool],
+    wp_disable_xmlrpc:          ['security','wpDisableXmlrpc', oldBool],
 
     php_server:                 ['php', 'phpServer'],
     php_server_backup:          ['php', 'phpBackupServer'],


### PR DESCRIPTION
## Type of Change
<!-- What part of the source are you modifying? Remove the irrelevant options. -->

- **Tool Source:** Vue and JS
- **Something else:** Nginx config script for wordpress

## What issue does this relate to?
resolves #316

### What should this PR do?
This PR should add a boolean option to `disable xmlrpc` in wordpress config which is selected by default. If someone likes to enable it, they can uncheck the `disable xmlrpc` option and then xmlrpc endpoint would be allowed in nginx config.

### What are the acceptance criteria?
<!-- Write a list of what should reviewers be checking before they approve this PR. -->
<!-- If there are UI changes, include before and after screenshots in a table for comparison. -->
