### PR TITLE
allow the Podlove subscribe button widget

### DIFF
--- a/src/nginxconfig/generators/conf/wordpress.conf.js
+++ b/src/nginxconfig/generators/conf/wordpress.conf.js
@@ -48,6 +48,9 @@ export default (global, domain) => {
     config['# WordPress: SEO plugin'] = '';
     config['location ~* ^/wp-content/plugins/wordpress-seo(?:-premium)?/css/main-sitemap\\.xsl$'] = {};
 
+    config['# WordPress: allow Podlove subscribe button widget'] = '';
+    config['location ~ ^/wp-content/plugins/podlove-podcasting-plugin-for-wordpress/lib/modules/subscribe_button/dist/button\\.html'] = {};
+
     config['# WordPress: deny wp-content/plugins (except earlier rules)'] = '';
     config['location ~ ^/wp-content/plugins'] = {
         deny: 'all',


### PR DESCRIPTION
## Type of Change

Update to the generator for the WordPress configuration.

### What should this PR do?

- Fixing the subscribe button widget from being blocked through the rule denying all files in `wp-content/plugins`.

### What are the acceptance criteria?

- Check, if the generator still builds a valid WordPress configuration file.