### PR TITLE
Update workflows with v3 actions + permissions

### DIFF
--- a/.github/workflows/do-spaces-workflow.yml
+++ b/.github/workflows/do-spaces-workflow.yml
@@ -2,17 +2,21 @@ name: Deploy to DigitalOcean Spaces
 
 on: push
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-      - name: Setup Node
-        uses: actions/setup-node@v3.5.0
+      - name: Use Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Setup NPM
@@ -40,7 +44,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SPACES_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.SPACES_REGION }}
 
-      - name: Leave a comment
+      - name: Leave a comment on commit
         run: npm run deploy:spaces:comment
         env:
           REPO_NAME: ${{ github.repository }}

--- a/.github/workflows/gh-pages-workflow.yml
+++ b/.github/workflows/gh-pages-workflow.yml
@@ -5,17 +5,25 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
+concurrency:
+  group: gh-pages-workflow
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-      - name: Setup Node
-        uses: actions/setup-node@v3.5.0
+      - name: Use Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Setup NPM
@@ -40,9 +48,8 @@ jobs:
           NODE_ENV: production
 
       - name: Deploy master to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@2.0.0
-        env:
-          ACCESS_TOKEN: ${{ secrets.DEV_GITHUB_TOKEN }}
-          BASE_BRANCH: master
-          BRANCH: gh-pages
-          FOLDER: dist
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dist
+          clean: true
+          single-commit: true

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -7,12 +7,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-      - name: Setup Node
-        uses: actions/setup-node@v3.5.0
+      - name: Use Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Setup NPM
@@ -35,12 +36,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-      - name: Setup Node
-        uses: actions/setup-node@v3.5.0
+      - name: Use Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Setup NPM
@@ -63,12 +65,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-      - name: Setup Node
-        uses: actions/setup-node@v3.5.0
+      - name: Use Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Setup NPM


### PR DESCRIPTION
## Type of Change

- **Something else:** Actions workflows

## What issue does this relate to?

cc https://github.com/do-community/do-bulma/pull/53

### What should this PR do?

Updates Actions workflows to use checkout/setup-node@v3, use github-pages-deploy-action@v4 (which no longer needs a custom token), sets the permissions for the Spaces workflow to explicitly include write access to the contents so commit comments can be added, and sets the Pages workflow to explicitly include write access to the contents so it can deploy.

### What are the acceptance criteria?

Workflows continue to run.