### PR TITLE
Fix Webpack magic comments for Windows

### DIFF
--- a/src/nginxconfig/i18n/setup.js
+++ b/src/nginxconfig/i18n/setup.js
@@ -46,7 +46,7 @@ export const getI18n = async () => {
         if (availablePack === defaultPack) continue;
         if (i18nPacks[availablePack]) continue;
         const { default: languageData } = await import(
-            /* webpackInclude: /i18n\/[^/]+\/languages\.js$/ */
+            /* webpackInclude: /i18n[\/\\][^\/\\]+[\/\\]languages\.js$/ */
             /* webpackMode: "eager" */
             `./${toSep(availablePack, '-')}/languages.js`
         );
@@ -72,7 +72,7 @@ const loadLanguagePack = async pack => {
     // Load in the full pack
     // Use webpack magic to only build chunks for lang/index.js
     const { default: packData } = await import(
-        /* webpackInclude: /i18n\/[^/]+\/index\.js$/ */
+        /* webpackInclude: /i18n[\/\\][^\/\\]+[\/\\]index\.js$/ */
         /* webpackMode: "lazy" */
         `./${toSep(pack, '-')}/index.js`
     );


### PR DESCRIPTION
## Type of Change

- **Tool Source:** i18n JS

## What issue does this relate to?

Resolves #408

### What should this PR do?

Fixes the Webpack magic comments used to determine what i18n files to include in the dynamic comments. Native JS will handle using `/` as the directory separator on Windows, but it seems that the RegEx patterns used by the Webpack magic comments do not map that, and so need to explicitly support using `\` as the separator.

### What are the acceptance criteria?

On Windows systems, the tool builds and runs as expected. On BSD/Linux systems, the tool builds and runs as expected.