### PR TITLE
Add warning for ssl off directive during Cerbox setup

### DIFF
--- a/src/nginxconfig/i18n/de/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/de/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2023 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -30,6 +30,7 @@ const certbot = 'Certbot';
 
 export default {
     commentOutSslDirectivesInConfiguration: `Kommentiere ${common.ssl}-relevante Direktiven in deiner Konfiguration aus:`,
+    sslOffDeprecationWarning: `This command will add a temporary <code class="slim">ssl off</code> directive to ensure that ${common.ssl} directives are not active. This may cause ${common.nginx} to emit a warning, which is safe to ignore. The directive will be removed once ${certbot} is configured.`, // TODO: translate
     reloadYourNginxServer: `Führe einen reload deines ${common.nginx} Server aus:`,
     obtainSslCertificatesFromLetsEncrypt: `Erhalte ${common.ssl} Zertifikate von ${common.letsEncrypt} mittels ${certbot}:`,
     uncommentSslDirectivesInConfiguration: `Kommentiere ${common.ssl}-relevante Direktiven in deiner Konfiguration ein:`,

--- a/src/nginxconfig/i18n/en/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/en/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2023 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -30,6 +30,7 @@ const certbot = 'Certbot';
 
 export default {
     commentOutSslDirectivesInConfiguration: `Comment out ${common.ssl} related directives in the configuration:`,
+    sslOffDeprecationWarning: `This command will add a temporary <code class="slim">ssl off</code> directive to ensure that ${common.ssl} directives are not active. This may cause ${common.nginx} to emit a warning, which is safe to ignore. The directive will be removed once ${certbot} is configured.`,
     reloadYourNginxServer: `Reload your ${common.nginx} server:`,
     obtainSslCertificatesFromLetsEncrypt: `Obtain ${common.ssl} certificates from ${common.letsEncrypt} using ${certbot}:`,
     uncommentSslDirectivesInConfiguration: `Uncomment ${common.ssl} related directives in the configuration:`,

--- a/src/nginxconfig/i18n/es/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/es/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2023 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -30,6 +30,7 @@ const certbot = 'Certbot';
 
 export default {
     commentOutSslDirectivesInConfiguration: `Comente las directivas relacionadas con ${common.ssl} en la configuración:`,
+    sslOffDeprecationWarning: `This command will add a temporary <code class="slim">ssl off</code> directive to ensure that ${common.ssl} directives are not active. This may cause ${common.nginx} to emit a warning, which is safe to ignore. The directive will be removed once ${certbot} is configured.`, // TODO: translate
     reloadYourNginxServer: `Recargar el ${common.nginx}:`,
     obtainSslCertificatesFromLetsEncrypt: `Obtenga los certificados ${common.ssl} de ${common.letsEncrypt} usando ${certbot}:`,
     uncommentSslDirectivesInConfiguration: `Comente las directivas relacionadas con ${common.ssl} en la configuración:`,

--- a/src/nginxconfig/i18n/fr/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/fr/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2023 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -30,6 +30,7 @@ const certbot = 'Certbot';
 
 export default {
     commentOutSslDirectivesInConfiguration: `Commentez les directives relatives à ${common.ssl}:`,
+    sslOffDeprecationWarning: `This command will add a temporary <code class="slim">ssl off</code> directive to ensure that ${common.ssl} directives are not active. This may cause ${common.nginx} to emit a warning, which is safe to ignore. The directive will be removed once ${certbot} is configured.`, // TODO: translate
     reloadYourNginxServer: `Relancez le serveur ${common.nginx}:`,
     obtainSslCertificatesFromLetsEncrypt: `Obtenez les certificats ${common.ssl} de ${common.letsEncrypt} à l'aide de ${certbot}:`,
     uncommentSslDirectivesInConfiguration: `Décommentez les directives relatives à ${common.ssl}:`,

--- a/src/nginxconfig/i18n/fr/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/fr/templates/setup_sections/certbot.js
@@ -30,7 +30,7 @@ const certbot = 'Certbot';
 
 export default {
     commentOutSslDirectivesInConfiguration: `Commentez les directives relatives à ${common.ssl}:`,
-    sslOffDeprecationWarning: `This command will add a temporary <code class="slim">ssl off</code> directive to ensure that ${common.ssl} directives are not active. This may cause ${common.nginx} to emit a warning, which is safe to ignore. The directive will be removed once ${certbot} is configured.`, // TODO: translate
+    sslOffDeprecationWarning: `Cette commande ajoutera une directive temporaire <code class="slim">ssl off</code> pour s'assurer que les directives ${common.ssl} ne sont pas actives. Cela peut amener ${common.nginx} à émettre un avertissement, qui peut être ignoré en toute sécurité. La directive sera supprimée une fois que ${certbot} sera configuré.`,
     reloadYourNginxServer: `Relancez le serveur ${common.nginx}:`,
     obtainSslCertificatesFromLetsEncrypt: `Obtenez les certificats ${common.ssl} de ${common.letsEncrypt} à l'aide de ${certbot}:`,
     uncommentSslDirectivesInConfiguration: `Décommentez les directives relatives à ${common.ssl}:`,

--- a/src/nginxconfig/i18n/ja/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/ja/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -30,6 +30,7 @@ const certbot = 'Certbot';
 
 export default {
     commentOutSslDirectivesInConfiguration: `設定中の ${common.ssl} 関連ディレクティブをコメントアウトします:`,
+    sslOffDeprecationWarning: `This command will add a temporary <code class="slim">ssl off</code> directive to ensure that ${common.ssl} directives are not active. This may cause ${common.nginx} to emit a warning, which is safe to ignore. The directive will be removed once ${certbot} is configured.`, // TODO: translate
     reloadYourNginxServer: `${common.nginx} サーバをリロードします:`,
     obtainSslCertificatesFromLetsEncrypt: `${certbot} を利用して、 ${common.ssl} 証明書を ${common.letsEncrypt} から取得します:`,
     uncommentSslDirectivesInConfiguration: `設定中の ${common.ssl} 関連ディレクティブのコメントアウトを外します:`,

--- a/src/nginxconfig/i18n/pl/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/pl/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2023 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -30,6 +30,7 @@ const certbot = 'Certbot';
 
 export default {
     commentOutSslDirectivesInConfiguration: `Zakomentuj dyrektywy związane z ${common.ssl} w pliku konfiguracyjnym:`,
+    sslOffDeprecationWarning: `This command will add a temporary <code class="slim">ssl off</code> directive to ensure that ${common.ssl} directives are not active. This may cause ${common.nginx} to emit a warning, which is safe to ignore. The directive will be removed once ${certbot} is configured.`, // TODO: translate
     reloadYourNginxServer: `Przeładuj usługę ${common.nginx}:`,
     obtainSslCertificatesFromLetsEncrypt: `Uzysjak certyfikat ${common.ssl} od ${common.letsEncrypt} za pomocą ${certbot}:`,
     uncommentSslDirectivesInConfiguration: `Odkomentuj dyrektywy związane z ${common.ssl} w pliku konfiguracyjnym:`,

--- a/src/nginxconfig/i18n/pt-br/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/pt-br/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2023 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -30,6 +30,7 @@ const certbot = 'Certbot';
 
 export default {
     commentOutSslDirectivesInConfiguration: `Comente as diretivas relacionadas ao ${common.ssl} na configuração:`,
+    sslOffDeprecationWarning: `This command will add a temporary <code class="slim">ssl off</code> directive to ensure that ${common.ssl} directives are not active. This may cause ${common.nginx} to emit a warning, which is safe to ignore. The directive will be removed once ${certbot} is configured.`, // TODO: translate
     reloadYourNginxServer: `Recarregue seu servidor ${common.nginx}:`,
     obtainSslCertificatesFromLetsEncrypt: `Obtenha certificados ${common.ssl} de ${common.letsEncrypt} usando o ${certbot}:`,
     uncommentSslDirectivesInConfiguration: `Descomente as diretivas relacionadas ao ${common.ssl} na configuração:`,

--- a/src/nginxconfig/i18n/ru/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/ru/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2023 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -30,6 +30,7 @@ const certbot = 'Certbot';
 
 export default {
     commentOutSslDirectivesInConfiguration: `Закомментируйте директивы, связанные с ${common.ssl} в конфигурации:`,
+    sslOffDeprecationWarning: `This command will add a temporary <code class="slim">ssl off</code> directive to ensure that ${common.ssl} directives are not active. This may cause ${common.nginx} to emit a warning, which is safe to ignore. The directive will be removed once ${certbot} is configured.`, // TODO: translate
     reloadYourNginxServer: `Перезагрузите свой ${common.nginx} сервер:`,
     obtainSslCertificatesFromLetsEncrypt: `Получите ${common.ssl} сертификат ${common.letsEncrypt} используя ${certbot}:`,
     uncommentSslDirectivesInConfiguration: `Раскомментируйте директивы, связанные с ${common.ssl} в конфигурации:`,

--- a/src/nginxconfig/i18n/zh-cn/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2023 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -30,6 +30,7 @@ const certbot = 'Certbot';
 
 export default {
     commentOutSslDirectivesInConfiguration: `注释掉配置中的${common.ssl}相关指令:`,
+    sslOffDeprecationWarning: `This command will add a temporary <code class="slim">ssl off</code> directive to ensure that ${common.ssl} directives are not active. This may cause ${common.nginx} to emit a warning, which is safe to ignore. The directive will be removed once ${certbot} is configured.`, // TODO: translate
     reloadYourNginxServer: `重新加载你的${common.nginx}服务器:`,
     obtainSslCertificatesFromLetsEncrypt: `使用${certbot}从 ${common.letsEncrypt} 获得${common.ssl}证书:`,
     uncommentSslDirectivesInConfiguration: `在配置中取消注释${common.ssl}相关指令:`,

--- a/src/nginxconfig/i18n/zh-tw/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -30,6 +30,7 @@ const certbot = 'Certbot';
 
 export default {
     commentOutSslDirectivesInConfiguration: `註解掉設定中的 ${common.ssl} 相關指令：`,
+    sslOffDeprecationWarning: `This command will add a temporary <code class="slim">ssl off</code> directive to ensure that ${common.ssl} directives are not active. This may cause ${common.nginx} to emit a warning, which is safe to ignore. The directive will be removed once ${certbot} is configured.`, // TODO: translate
     reloadYourNginxServer: `重新載入您的 ${common.nginx} 伺服器：`,
     obtainSslCertificatesFromLetsEncrypt: `使用 ${certbot} 從 ${common.letsEncrypt} 取得 ${common.ssl} 憑證：`,
     uncommentSslDirectivesInConfiguration: `在設定中取消註解 ${common.ssl} 相關指令：`,

--- a/src/nginxconfig/scss/_code.scss
+++ b/src/nginxconfig/scss/_code.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2023 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -63,6 +63,22 @@ pre {
 .code-toolbar {
   > .toolbar {
     right: calc(.2em + 16px);
+
+    > .toolbar-item {
+      > button {
+        background: rgba($input, .9);
+        border: 1px solid $input-border;
+        color: rgba($input-border, .75);
+        cursor: pointer;
+        transition: color $transition, background $transition;
+
+        &:hover,
+        &:focus {
+          background: $input;
+          color: $input-border;
+        }
+      }
+    }
   }
 }
 

--- a/src/nginxconfig/templates/domain_sections/presets.vue
+++ b/src/nginxconfig/templates/domain_sections/presets.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -35,9 +35,9 @@ THE SOFTWARE.
 
         <template v-if="!$parent.$props.data.hasUserInteraction || expanded">
             <div v-if="$parent.$props.data.hasUserInteraction" class="message is-warning">
-                <div class="message-body">
+                <p class="message-body">
                     {{ $t('templates.domainSections.presets.itLooksLikeYouCustomisedTheConfig') }}
-                </div>
+                </p>
             </div>
 
             <div class="buttons-group">

--- a/src/nginxconfig/templates/global_sections/security.vue
+++ b/src/nginxconfig/templates/global_sections/security.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -62,7 +62,7 @@ THE SOFTWARE.
                             <span
                                 class="message-body"
                                 v-html="$t('templates.globalSections.security.whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality')"
-                            ></span>
+                            />
                         </label>
                     </div>
                 </div>

--- a/src/nginxconfig/templates/setup_sections/certbot.vue
+++ b/src/nginxconfig/templates/setup_sections/certbot.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -37,6 +37,10 @@ THE SOFTWARE.
                     :cmd="`sed -i -r 's/(listen .*443)/\\1; #/g; s/(ssl_(certificate|certificate_key|trusted_certificate) )/#;#\\1/g; s/(server \\{)/\\1\\n    ssl off;/g' ${sitesAvailable}`"
                     @copied="codeCopiedEvent('Disable ssl directives')"
                 ></BashPrism>
+
+                <div class="text message is-warning">
+                    <p class="message-body" v-html="$t('templates.setupSections.certbot.sslOffDeprecationWarning')" />
+                </div>
             </li>
 
             <li>

--- a/src/nginxconfig/templates/setup_sections/certbot.vue
+++ b/src/nginxconfig/templates/setup_sections/certbot.vue
@@ -39,7 +39,10 @@ THE SOFTWARE.
                 ></BashPrism>
 
                 <div class="text message is-warning">
-                    <p class="message-body" v-html="$t('templates.setupSections.certbot.sslOffDeprecationWarning')" />
+                    <p
+                        class="message-body"
+                        v-html="$t('templates.setupSections.certbot.sslOffDeprecationWarning')"
+                    />
                 </div>
             </li>
 


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Certbot setup

## What issue does this relate to?

cc #333 #256 #215

### What should this PR do?

Adds a warning/explanation note after the Certbox instruction that adds the `ssl off` directive, to clarify that the warning it may produce can be ignored as this directive is only temporary while Certbot is configured.

### What are the acceptance criteria?

Warning shows below the first command in the Certbot setup step.