### PR TITLE
Only generate WordPress config for domains with WordPress enabled

### DIFF
--- a/src/nginxconfig/generators/index.js
+++ b/src/nginxconfig/generators/index.js
@@ -64,7 +64,8 @@ export default (domains, global) => {
             files[`${sitesDir}/${domain.server.domain.computed}.conf`] = toConf(websiteConf(domain, domains, global, ipPortPairs));
             // WordPress
             if (domains.some(d => d.php.wordPressRules.computed))
-                files[`nginxconfig.io/${domain.server.domain.computed}.wordpress.conf`] = toConf(wordPressConf(global, domain));
+                if (domain.php.wordPressRules.computed)
+                    files[`nginxconfig.io/${domain.server.domain.computed}.wordpress.conf`] = toConf(wordPressConf(global, domain));
         }
 
         // Let's encrypt


### PR DESCRIPTION
## Type of Change

Generation of configuration

## What issue does this relate to?

Resolves #435 

### What should this PR do?

Fix the issue #435 by switching the generation for the WordPress config to only happen on domains with WordPress, rather than all domains when any domain has WordPress.

### What are the acceptance criteria?

The pull request need fix the issue and cannot break the app

Please, tag this pull request to make a point in Hacktoberfest 2023
