### PR TITLE
Fix email link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,6 @@ Give a ⭐️ if this project helped you!
 
 ## 📝 License
 
-Copyright © 2020 [DigitalOcean, Inc &lt;contact@digitalocean.com&gt; (https://www.digitalocean.com)](https://www.digitalocean.com).
+Copyright © 2020 [DigitalOcean, Inc](https://www.digitalocean.com) &lt;contact@digitalocean.com&gt; (https://www.digitalocean.com).
 <br />
 This project is licensed under the [MIT](https://github.com/digitalocean/nginxconfig.io/blob/master/LICENSE) license.


### PR DESCRIPTION
## Type of Change
Update Readme

- **Update Readme:** On clicking the email of digitalocean, it opens a mail link rather than the website. 

## What issue does this relate to?
None

### What should this PR do?
 On clicking the email of digitalocean, it opens a mail link rather than the website.

### What are the acceptance criteria?
 On clicking the email of digitalocean, it opens a mail link rather than the website.
<img width="1117" alt="image" src="https://github.com/digitalocean/nginxconfig.io/assets/26411488/237a7d27-5bfe-4676-8a6a-79deb21a0438">
