### PR TITLE
Update how HTTP/2 is enabled

### DIFF
--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -73,9 +73,6 @@ const httpsListen = (domain, global, ipPortPairs) => {
     // HTTPS
     config.push(['listen', `${ipPortV4} ssl${reusePortV4 ? ' reuseport' : ''}`]);
 
-    // HTTP/2
-    if (domain.https.http2.computed) config.push(['http2', 'on']);
-
     // HTTP/3
     if (domain.https.http3.computed) config.push(['listen', `${ipPortV4} http3`]);
 
@@ -92,6 +89,9 @@ const httpsListen = (domain, global, ipPortPairs) => {
         // HTTP/3
         if (domain.https.http3.computed) config.push(['listen', `${ipPortV6} http3`]);
     }
+
+    // HTTP/2
+    if (domain.https.http2.computed) config.push(['http2', 'on']);
 
     return config;
 };

--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -71,12 +71,10 @@ const httpsListen = (domain, global, ipPortPairs) => {
     if (reusePortV4) ipPortPairs.add(ipPortV4);
 
     // HTTPS
-    config.push([
-        'listen',
-        `${ipPortV4} ssl${domain.https.http2.computed ? ' http2' : ''}${
-            reusePortV4 ? ' reuseport' : ''
-        }`,
-    ]);
+    config.push(['listen', `${ipPortV4} ssl${reusePortV4 ? ' reuseport' : ''}`]);
+
+    // HTTP/2
+    if (domain.https.http2.computed) config.push(['http2', 'on']);
 
     // HTTP/3
     if (domain.https.http3.computed) config.push(['listen', `${ipPortV4} http3`]);
@@ -89,12 +87,7 @@ const httpsListen = (domain, global, ipPortPairs) => {
         if (reusePortV6) ipPortPairs.add(ipPortV6);
 
         // HTTPS
-        config.push([
-            'listen',
-            `${ipPortV6} ssl${domain.https.http2.computed ? ' http2' : ''}${
-                reusePortV6 ? ' reuseport' : ''
-            }`,
-        ]);
+        config.push(['listen', `${ipPortV6} ssl${reusePortV6 ? ' reuseport' : ''}`]);
 
         // HTTP/3
         if (domain.https.http3.computed) config.push(['listen', `${ipPortV6} http3`]);


### PR DESCRIPTION
## Type of Change

- **Something else:** Updates how HTTP/2 is enabled using the new `http2 on` method instead of `listen ... http2`

## What issue does this relate to?
<!-- Use a GitHub keyword ('resolves #xx', 'fixes #xx', 'closes #xx') to automatically close the relevant issue. -->

Resolves #451 

### What should this PR do?
Changes how HTTP2 is enabled with 

### What are the acceptance criteria?
Verify that new HTTP/2 directive matches the [docs](https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2).

Previous
![firefox_AIwZwD86ZG](https://github.com/digitalocean/nginxconfig.io/assets/13918954/6646c797-4fea-4850-9e11-f00d5d57e296)


With changes
![firefox_uKflHkIgPI](https://github.com/digitalocean/nginxconfig.io/assets/13918954/a362e95f-4d39-40cc-8588-d51bd0fa7018)


