### PR TITLE
Refactor imports to have file extensions to comply with ESM standards

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,8 +79,6 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-vue": "^9.20.1",
-    "esm": "^3.2.25",
-    "extensionless": "^1.9.6",
     "husky": "^8.0.3",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/src/nginxconfig/build/webpack-dynamic-import.js
+++ b/src/nginxconfig/build/webpack-dynamic-import.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { info } from '../util/log';
+import { info } from '../util/log.js';
 
 const originalSrcDir = document.currentScript.src.split('/').slice(0, -2).join('/') + '/';
 window.__webpackDynamicImportURL = () => {

--- a/src/nginxconfig/generators/conf/general.conf.js
+++ b/src/nginxconfig/generators/conf/general.conf.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { gzipTypes, extensions } from '../../util/types_extensions';
+import { gzipTypes, extensions } from '../../util/types_extensions.js';
 
 export default (domains, global) => {
     const config = {};

--- a/src/nginxconfig/generators/conf/nginx.conf.js
+++ b/src/nginxconfig/generators/conf/nginx.conf.js
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { errorLogPathDisabled } from '../../util/logging';
-import sslProfiles from '../../util/ssl_profiles';
-import websiteConf from './website.conf';
+import { errorLogPathDisabled } from '../../util/logging.js';
+import sslProfiles from '../../util/ssl_profiles.js';
+import websiteConf from './website.conf.js';
 
 export default (domains, global) => {
     const config = {};

--- a/src/nginxconfig/generators/conf/security.conf.js
+++ b/src/nginxconfig/generators/conf/security.conf.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import commonHsts from '../../util/common_hsts';
+import commonHsts from '../../util/common_hsts.js';
 
 export default (domains, global) => {
     const config = [];

--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -24,22 +24,22 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { getSslCertificate, getSslCertificateKey } from '../../util/get_ssl_certificate';
-import { extensions, gzipTypes } from '../../util/types_extensions';
-import { getDomainAccessLog, getDomainErrorLog } from '../../util/logging';
-import commonHsts from '../../util/common_hsts';
-import securityConf from './security.conf';
-import pythonConf from './python_uwsgi.conf';
-import proxyConf from './proxy.conf';
-import phpConf from './php_fastcgi.conf';
-import generalConf from './general.conf';
-import wordPressConf from './wordpress.conf';
-import drupalConf from './drupal.conf';
-import magentoConf from './magento.conf';
-import joomlaConf from './joomla.conf';
-import letsEncryptConf from './letsencrypt.conf';
-import phpPath from '../../util/php_path';
-import phpUpstream from '../../util/php_upstream';
+import { getSslCertificate, getSslCertificateKey } from '../../util/get_ssl_certificate.js';
+import { extensions, gzipTypes } from '../../util/types_extensions.js';
+import { getDomainAccessLog, getDomainErrorLog } from '../../util/logging.js';
+import commonHsts from '../../util/common_hsts.js';
+import securityConf from './security.conf.js';
+import pythonConf from './python_uwsgi.conf.js';
+import proxyConf from './proxy.conf.js';
+import phpConf from './php_fastcgi.conf.js';
+import generalConf from './general.conf.js';
+import wordPressConf from './wordpress.conf.js';
+import drupalConf from './drupal.conf.js';
+import magentoConf from './magento.conf.js';
+import joomlaConf from './joomla.conf.js';
+import letsEncryptConf from './letsencrypt.conf.js';
+import phpPath from '../../util/php_path.js';
+import phpUpstream from '../../util/php_upstream.js';
 
 const sslConfig = (domain, global) => {
     const config = [];

--- a/src/nginxconfig/generators/conf/wordpress.conf.js
+++ b/src/nginxconfig/generators/conf/wordpress.conf.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import phpPath from '../../util/php_path';
-import phpUpstream from '../../util/php_upstream';
+import phpPath from '../../util/php_path.js';
+import phpUpstream from '../../util/php_upstream.js';
 
 export default (global, domain) => {
     const config = {};

--- a/src/nginxconfig/generators/index.js
+++ b/src/nginxconfig/generators/index.js
@@ -24,23 +24,23 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import toConf from './to_conf';
-import toYaml from './to_yaml';
-import nginxConf from './conf/nginx.conf';
-import websiteConf from './conf/website.conf';
-import letsEncryptConf from './conf/letsencrypt.conf';
-import securityConf from './conf/security.conf';
-import generalConf from './conf/general.conf';
-import phpConf from './conf/php_fastcgi.conf';
-import pythonConf from './conf/python_uwsgi.conf';
-import proxyConf from './conf/proxy.conf';
-import wordPressConf from './conf/wordpress.conf';
-import drupalConf from './conf/drupal.conf';
-import magentoConf from './conf/magento.conf';
-import joomlaConf from './conf/joomla.conf';
-import dockerComposeYaml from './yaml/dockerCompose.yaml';
-import dockerConf from './ext/docker';
-import shareQuery from '../util/share_query';
+import toConf from './to_conf.js';
+import toYaml from './to_yaml.js';
+import nginxConf from './conf/nginx.conf.js';
+import websiteConf from './conf/website.conf.js';
+import letsEncryptConf from './conf/letsencrypt.conf.js';
+import securityConf from './conf/security.conf.js';
+import generalConf from './conf/general.conf.js';
+import phpConf from './conf/php_fastcgi.conf.js';
+import pythonConf from './conf/python_uwsgi.conf.js';
+import proxyConf from './conf/proxy.conf.js';
+import wordPressConf from './conf/wordpress.conf.js';
+import drupalConf from './conf/drupal.conf.js';
+import magentoConf from './conf/magento.conf.js';
+import joomlaConf from './conf/joomla.conf.js';
+import dockerComposeYaml from './yaml/dockerCompose.yaml.js';
+import dockerConf from './ext/docker.js';
+import shareQuery from '../util/share_query.js';
 
 export default (domains, global) => {
     const files = {};

--- a/src/nginxconfig/generators/to_conf.js
+++ b/src/nginxconfig/generators/to_conf.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import isObject from '../util/is_object';
+import isObject from '../util/is_object.js';
 
 const isBlock = (item) => {
     // If an object, or kv entries, this is considered a block

--- a/src/nginxconfig/i18n/de/index.js
+++ b/src/nginxconfig/i18n/de/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/de/templates/app.js
+++ b/src/nginxconfig/i18n/de/templates/app.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../common';
+import common from '../common.js';
 
 export default {
     title: `${common.nginx}Config`,

--- a/src/nginxconfig/i18n/de/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/de/templates/callouts/index.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import droplet from './droplet';
-import contribute from './contribute';
+import droplet from './droplet.js';
+import contribute from './contribute.js';
 
 export default { droplet, contribute };

--- a/src/nginxconfig/i18n/de/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/https.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableEncryptedSslConnection: `${common.enable} verschlüsselte ${common.ssl} Verbindungen`,

--- a/src/nginxconfig/i18n/de/templates/domain_sections/index.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/index.js
@@ -24,16 +24,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import onion from './onion';
-import php from './php';
-import presets from './presets';
-import python from './python';
-import restrict from './restrict';
-import reverseProxy from './reverse_proxy';
-import routing from './routing';
-import server from './server';
+import https from './https.js';
+import logging from './logging.js';
+import onion from './onion.js';
+import php from './php.js';
+import presets from './presets.js';
+import python from './python.js';
+import restrict from './restrict.js';
+import reverseProxy from './reverse_proxy.js';
+import routing from './routing.js';
+import server from './server.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/de/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/php.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     phpIsDisabled: `${common.php} ist deaktiviert.`,

--- a/src/nginxconfig/i18n/de/templates/domain_sections/python.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/python.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonIsDisabled: `${common.python} ist deaktiviert.`,

--- a/src/nginxconfig/i18n/de/templates/domain_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/reverse_proxy.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     reverseProxyIsDisabled: `${common.reverseProxy} ist deaktiviert.`,

--- a/src/nginxconfig/i18n/de/templates/domain_sections/routing.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/routing.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     fallbackRouting: 'Fallback Routing',

--- a/src/nginxconfig/i18n/de/templates/global_sections/docker.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/docker.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const docker = 'Docker';
 const dockerfile = 'Dockerfile';

--- a/src/nginxconfig/i18n/de/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/https.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const mozilla = 'Mozilla';
 const ipv4 = 'IPv4';

--- a/src/nginxconfig/i18n/de/templates/global_sections/index.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/index.js
@@ -24,15 +24,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import nginx from './nginx';
-import performance from './performance';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import security from './security';
-import tools from './tools';
-import docker from './docker';
+import https from './https.js';
+import logging from './logging.js';
+import nginx from './nginx.js';
+import performance from './performance.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import security from './security.js';
+import tools from './tools.js';
+import docker from './docker.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/de/templates/global_sections/logging.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/logging.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableFileNotFoundErrorLogging: `${common.enable} "Seite nicht gefunden" Error Logging in`,

--- a/src/nginxconfig/i18n/de/templates/global_sections/nginx.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/nginx.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     nginxConfigDirectory: `${common.nginx} Konfigurationsverzeichnis`,

--- a/src/nginxconfig/i18n/de/templates/global_sections/performance.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/performance.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     disableHtmlCaching: 'Disable HTML caching', // TODO: translate

--- a/src/nginxconfig/i18n/de/templates/global_sections/python.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/python.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonServer: `${common.python} Server`,

--- a/src/nginxconfig/i18n/de/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/reverse_proxy.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const legacyXForwarded = 'Legacy X-Forwarded-* Header';
 

--- a/src/nginxconfig/i18n/de/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/security.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `Bei der Verwendung von ${common.wordPress} ist es oft nötig, <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code> in die Content Security Policy aufzunehmen, damit der Admin-Bereich korrekt funktioniert.`,

--- a/src/nginxconfig/i18n/de/templates/global_sections/tools.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/tools.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     modularizedStructure: 'Modularisierte Struktur',

--- a/src/nginxconfig/i18n/de/templates/index.js
+++ b/src/nginxconfig/i18n/de/templates/index.js
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import app from './app';
-import setup from './setup';
-import footer from './footer';
+import app from './app.js';
+import setup from './setup.js';
+import footer from './footer.js';
 import domainSections from './domain_sections';
 import globalSections from './global_sections';
 import setupSections from './setup_sections';

--- a/src/nginxconfig/i18n/de/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/de/templates/setup_sections/certbot.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const certbot = 'Certbot';
 

--- a/src/nginxconfig/i18n/de/templates/setup_sections/download.js
+++ b/src/nginxconfig/i18n/de/templates/setup_sections/download.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     downloadTheGeneratedConfig: 'Generierte Konfigurationsdateien <b>herunterladen</b>:',

--- a/src/nginxconfig/i18n/de/templates/setup_sections/go_live.js
+++ b/src/nginxconfig/i18n/de/templates/setup_sections/go_live.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     letsGoLive: 'Jetzt gehts los!',

--- a/src/nginxconfig/i18n/de/templates/setup_sections/index.js
+++ b/src/nginxconfig/i18n/de/templates/setup_sections/index.js
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import certbot from './certbot';
-import download from './download';
-import goLive from './go_live';
-import ssl from './ssl';
+import certbot from './certbot.js';
+import download from './download.js';
+import goLive from './go_live.js';
+import ssl from './ssl.js';
 
 export default { certbot, download, goLive, ssl };

--- a/src/nginxconfig/i18n/de/templates/setup_sections/ssl.js
+++ b/src/nginxconfig/i18n/de/templates/setup_sections/ssl.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     generateDiffieHellmanKeysByRunningThisCommandOnYourServer:

--- a/src/nginxconfig/i18n/en/index.js
+++ b/src/nginxconfig/i18n/en/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/es/index.js
+++ b/src/nginxconfig/i18n/es/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/fa/index.js
+++ b/src/nginxconfig/i18n/fa/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/fr/index.js
+++ b/src/nginxconfig/i18n/fr/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/ja/index.js
+++ b/src/nginxconfig/i18n/ja/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/pl/index.js
+++ b/src/nginxconfig/i18n/pl/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/pt-br/index.js
+++ b/src/nginxconfig/i18n/pt-br/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/ru/index.js
+++ b/src/nginxconfig/i18n/ru/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/setup.js
+++ b/src/nginxconfig/i18n/setup.js
@@ -25,7 +25,7 @@ THE SOFTWARE.
 */
 
 import { createI18n } from 'vue-i18n';
-import { defaultPack, defaultPackData, toSep, availablePacks } from '../util/language_packs';
+import { defaultPack, defaultPackData, toSep, availablePacks } from '../util/language_packs.js';
 
 // Load in the full default pack
 const i18nPacks = {};

--- a/src/nginxconfig/i18n/verify.js
+++ b/src/nginxconfig/i18n/verify.js
@@ -28,8 +28,8 @@ import { readdirSync, readFileSync } from 'fs';
 import { join, sep } from 'path';
 import { URL } from 'url';
 import chalk from 'chalk';
-import { defaultPack, availablePacks, toSep, fromSep } from '../util/language_packs';
-import snakeToCamel from '../util/snake_to_camel';
+import { defaultPack, availablePacks, toSep, fromSep } from '../util/language_packs.js';
+import snakeToCamel from '../util/snake_to_camel.js';
 
 // Recursively get all keys in a i18n pack object fragment
 const explore = (packFragment) => {

--- a/src/nginxconfig/i18n/zh-cn/index.js
+++ b/src/nginxconfig/i18n/zh-cn/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/zh-tw/index.js
+++ b/src/nginxconfig/i18n/zh-tw/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/mount.js
+++ b/src/nginxconfig/mount.js
@@ -28,8 +28,8 @@ THE SOFTWARE.
 import './scss/style.scss';
 import 'vue-select/dist/vue-select.css';
 import { createApp } from 'vue';
-import './util/prism_bundle';
-import { getI18n } from './i18n/setup';
+import './util/prism_bundle.js';
+import { getI18n } from './i18n/setup.js';
 import App from './templates/app';
 
 // Load the i18n languages and run the app

--- a/src/nginxconfig/util/analytics.js
+++ b/src/nginxconfig/util/analytics.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { info } from './log';
+import { info } from './log.js';
 
 export default ({ category, action, label, value, nonInteraction }) => {
     info('Analytics event:', { category, action, label, value, nonInteraction });

--- a/src/nginxconfig/util/angular_backwards_compatibility.js
+++ b/src/nginxconfig/util/angular_backwards_compatibility.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import isObject from './is_object';
+import isObject from './is_object.js';
 
 const oldBool = (val) => (val.toString().trim() === '' ? true : val);
 

--- a/src/nginxconfig/util/browser_language.js
+++ b/src/nginxconfig/util/browser_language.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { fromSep } from './language_packs';
+import { fromSep } from './language_packs.js';
 
 export default (availablePacks) => {
     if (typeof window === 'object' && typeof window.navigator === 'object') {

--- a/src/nginxconfig/util/computed_from_defaults.js
+++ b/src/nginxconfig/util/computed_from_defaults.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import isChanged from './is_changed';
+import isChanged from './is_changed.js';
 
 export default (defaults, cat, isInteraction = true) => {
     return Object.keys(defaults).reduce((prev, key) => {

--- a/src/nginxconfig/util/import_data.js
+++ b/src/nginxconfig/util/import_data.js
@@ -27,9 +27,9 @@ THE SOFTWARE.
 import qs from 'qs';
 import clone from 'clone';
 import Domain from '../templates/domain';
-import isObject from './is_object';
-import angularBackwardsCompatibility from './angular_backwards_compatibility';
-import vueBackwardsCompatibility from './vue_backwards_compatibility';
+import isObject from './is_object.js';
+import angularBackwardsCompatibility from './angular_backwards_compatibility.js';
+import vueBackwardsCompatibility from './vue_backwards_compatibility.js';
 
 const applyCategories = (categories, target) => {
     // Work through each potential category

--- a/src/nginxconfig/util/logging.js
+++ b/src/nginxconfig/util/logging.js
@@ -24,12 +24,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-export const accessLogPathDefault = '/var/log/nginx/access.log';
-export const accessLogParamsDefault = 'buffer=512k flush=1m';
+export const accessLogPathDefault = '/var/log/nginx/access.log.js';
+export const accessLogParamsDefault = 'buffer=512k flush=1m.js';
 
-export const errorLogPathDefault = '/var/log/nginx/error.log';
-export const errorLogPathDisabled = '/dev/null';
-export const errorLogLevelDefault = 'warn';
+export const errorLogPathDefault = '/var/log/nginx/error.log.js';
+export const errorLogPathDisabled = '/dev/null.js';
+export const errorLogLevelDefault = 'warn.js';
 export const errorLogLevelOptions = Object.freeze([
     'debug',
     'info',

--- a/src/nginxconfig/util/share_query.js
+++ b/src/nginxconfig/util/share_query.js
@@ -25,7 +25,7 @@ THE SOFTWARE.
 */
 
 import qs from 'qs';
-import exportData from './export_data';
+import exportData from './export_data.js';
 
 export default (domains, global) => {
     const data = exportData(domains, global);

--- a/src/nginxconfig/util/vue_backwards_compatibility.js
+++ b/src/nginxconfig/util/vue_backwards_compatibility.js
@@ -24,16 +24,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import isObject from './is_object';
-import deepMerge from './deep_merge';
+import isObject from './is_object.js';
+import deepMerge from './deep_merge.js';
 import {
     accessLogPathDefault,
     accessLogParamsDefault,
     errorLogPathDefault,
     errorLogPathDisabled,
     errorLogLevelDefault,
-} from './logging';
-import { serverDomainDefault } from './defaults';
+} from './logging.js';
+import { serverDomainDefault } from './defaults.js';
 
 // Migrate old logging settings to new ones
 const migrateLogging = (data) => {

--- a/test/testBrowserLanguage.js
+++ b/test/testBrowserLanguage.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import browserLanguage from '../src/nginxconfig/util/browser_language';
+import browserLanguage from '../src/nginxconfig/util/browser_language.js';
 
 class MockLocales {
     static languages = [];
@@ -83,23 +83,26 @@ class MockLocales {
     }
 }
 
-Object.defineProperty(window.navigator, 'languages', { get: () => {
-    return MockLocales.languages || [];
-}});
+Object.defineProperty(window.navigator, 'languages', {
+    get: () => {
+        return MockLocales.languages || [];
+    },
+});
 
-Object.defineProperty(window.navigator, 'language', { get: () => {
-    return MockLocales.language || null;
-}});
-
+Object.defineProperty(window.navigator, 'language', {
+    get: () => {
+        return MockLocales.language || null;
+    },
+});
 
 describe('browserLanguage', () => {
     test('Selects the first available exact match for language/region', () => {
         MockLocales.setDateTimeLocale(undefined);
 
-        MockLocales.setNavigatorLanguages(['zh-CN', 'zh','en-US','en']);
+        MockLocales.setNavigatorLanguages(['zh-CN', 'zh', 'en-US', 'en']);
         expect(browserLanguage(['en', 'zhCN', 'zhTW'])).toEqual('zhCN');
 
-        MockLocales.setNavigatorLanguages(['zh-TW','zh','en-US','en']);
+        MockLocales.setNavigatorLanguages(['zh-TW', 'zh', 'en-US', 'en']);
         expect(browserLanguage(['en', 'zhCN', 'zhTW'])).toEqual('zhTW');
 
         MockLocales.setNavigatorLanguages(['zh', 'en-US', 'en']);
@@ -108,7 +111,7 @@ describe('browserLanguage', () => {
         MockLocales.restoreDateTimeLocale();
     });
 
-    test('Selects the first available language match based on language/region',() => {
+    test('Selects the first available language match based on language/region', () => {
         MockLocales.setDateTimeLocale(undefined);
 
         MockLocales.setNavigatorLanguages(['ja-JP', 'ja', 'en-US']);
@@ -117,7 +120,7 @@ describe('browserLanguage', () => {
         MockLocales.restoreDateTimeLocale();
     });
 
-    test('Selects the first available language match based on language alone',() => {
+    test('Selects the first available language match based on language alone', () => {
         MockLocales.setDateTimeLocale(undefined);
 
         MockLocales.setNavigatorLanguages(['ja-JP', 'ja', 'zh']);
@@ -126,17 +129,17 @@ describe('browserLanguage', () => {
         MockLocales.restoreDateTimeLocale();
     });
 
-    test('Returns false when there is no available match',() => {
+    test('Returns false when there is no available match', () => {
         MockLocales.setDateTimeLocale(undefined);
 
-        MockLocales.setNavigatorLanguages(['ja-JP','ja']);
+        MockLocales.setNavigatorLanguages(['ja-JP', 'ja']);
         expect(browserLanguage(['en', 'zhCN', 'zhTW'])).toBeFalsy();
 
         MockLocales.restoreDateTimeLocale();
     });
 
     describe('Different sources for user locale', () => {
-        test('language, languages and Intl locale are `undefined`',() => {
+        test('language, languages and Intl locale are `undefined`', () => {
             MockLocales.setNavigatorLanguages(undefined);
             MockLocales.setNavigatorLanguage(undefined);
             MockLocales.setDateTimeLocale(undefined);
@@ -144,7 +147,7 @@ describe('browserLanguage', () => {
             MockLocales.restoreDateTimeLocale();
         });
 
-        test('language is `en`, languages and Intl locale are `undefined`',() => {
+        test('language is `en`, languages and Intl locale are `undefined`', () => {
             MockLocales.setNavigatorLanguage('en');
             MockLocales.setNavigatorLanguages(undefined);
             MockLocales.setDateTimeLocale(undefined);
@@ -152,15 +155,15 @@ describe('browserLanguage', () => {
             MockLocales.restoreDateTimeLocale();
         });
 
-        test('language and Intl locale are `undefined`, languages is `en-US, en`',() => {
+        test('language and Intl locale are `undefined`, languages is `en-US, en`', () => {
             MockLocales.setNavigatorLanguage(undefined);
-            MockLocales.setNavigatorLanguages(['en-US','en']);
+            MockLocales.setNavigatorLanguages(['en-US', 'en']);
             MockLocales.setDateTimeLocale(undefined);
             expect(browserLanguage(['en', 'zhCN', 'zhTW'])).toEqual('en');
             MockLocales.restoreDateTimeLocale();
         });
 
-        test('navigator is `undefined` and Intl locale is `en-US`',() => {
+        test('navigator is `undefined` and Intl locale is `en-US`', () => {
             MockLocales.setNavigator(undefined);
             MockLocales.setDateTimeLocale('en-US');
             expect(browserLanguage(['en', 'zhCN', 'zhTW'])).toEqual('en');


### PR DESCRIPTION
## Type of Change

- **Tool Source:** JS

## What issue does this relate to?

This PR resolves #454.

### What should this PR do?

All ESM imports in the project have been updated to include proper file extensions (e.g., `.js`) in line with modern ESM standards. The project’s `package.json` is also updated to mark it as a proper ESM module.

- Added file extensions to all import statements.
- Updated `package.json` to set `"type": "module"`.

### What are the acceptance criteria?

Please review and let me know if any adjustments are needed!
