### PR TITLE
Enforce file extensions in imports to comply with ESM standards

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -40,5 +40,5 @@ module.exports = {
         it: true,
         test: true,
     },
-    plugins: ['prettier'],
+    plugins: ['prettier', 'import'],
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -33,6 +33,14 @@ module.exports = {
         'vue/no-reserved-component-names': 0,
         'eol-last': ['error', 'always'],
         'prettier/prettier': 'error',
+        'import/extensions': [
+            'error',
+            'always',
+            {
+                js: 'never',
+                vue: 'never',
+            },
+        ],
     },
     globals: {
         describe: true,

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -37,8 +37,8 @@ module.exports = {
             'error',
             'always',
             {
-                js: 'never',
-                vue: 'never',
+                js: 'always',
+                vue: 'always',
             },
         ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,10 +40,9 @@
         "duplicate-package-checker-webpack-plugin": "^3.0.0",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-import": "^2.30.0",
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-vue": "^9.20.1",
-        "esm": "^3.2.25",
-        "extensionless": "^1.9.6",
         "husky": "^8.0.3",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -3293,6 +3292,12 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.24.tgz",
       "integrity": "sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ=="
     },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -4146,6 +4151,12 @@
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -5233,10 +5244,46 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
       "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
+      "integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "is-string": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -5245,6 +5292,84 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
+      "integrity": "sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+      "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+      "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.2.1",
+        "get-intrinsic": "^1.2.3",
+        "is-array-buffer": "^3.0.4",
+        "is-shared-array-buffer": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/assert": {
@@ -5319,9 +5444,12 @@
       }
     },
     "node_modules/available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -7130,6 +7258,57 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+      "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+      "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+      "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -8816,6 +8995,66 @@
         "stackframe": "^1.1.1"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
+      "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "arraybuffer.prototype.slice": "^1.0.3",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "data-view-buffer": "^1.0.1",
+        "data-view-byte-length": "^1.0.1",
+        "data-view-byte-offset": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-set-tostringtag": "^2.0.3",
+        "es-to-primitive": "^1.2.1",
+        "function.prototype.name": "^1.1.6",
+        "get-intrinsic": "^1.2.4",
+        "get-symbol-description": "^1.0.2",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.0.3",
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.0.7",
+        "is-array-buffer": "^3.0.4",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.1",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.3",
+        "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.13",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.13.1",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.5",
+        "regexp.prototype.flags": "^1.5.2",
+        "safe-array-concat": "^1.1.2",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.trim": "^1.2.9",
+        "string.prototype.trimend": "^1.0.8",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.2",
+        "typed-array-byte-length": "^1.0.1",
+        "typed-array-byte-offset": "^1.0.2",
+        "typed-array-length": "^1.0.6",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.15"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
@@ -8839,6 +9078,58 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.1.tgz",
       "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg=="
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.4",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+      "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+      "dev": true,
+      "dependencies": {
+        "hasown": "^2.0.0"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -8957,6 +9248,114 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
+      "integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.30.0.tgz",
+      "integrity": "sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==",
+      "dev": true,
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.8",
+        "array.prototype.findlastindex": "^1.2.5",
+        "array.prototype.flat": "^1.3.2",
+        "array.prototype.flatmap": "^1.3.2",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.9.0",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.15.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.0",
+        "semver": "^6.3.1",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -9400,15 +9799,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -9671,12 +10061,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/extensionless": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/extensionless/-/extensionless-1.9.6.tgz",
-      "integrity": "sha512-40F6zThJu1MxaT1A1pJ/2SHlU1BPYYnQNHt0j2ZlPuxxm2ddMcNc1D7uS/LGc4K3VwMEMaZLkCdHWaKk0LnQXA==",
-      "dev": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -10265,6 +10649,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "functions-have-names": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/fwd-stream": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/fwd-stream/-/fwd-stream-1.0.4.tgz",
@@ -10362,6 +10773,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+      "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -10429,6 +10857,22 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/globby": {
@@ -10522,15 +10966,13 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
+    "node_modules/has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-flag": {
@@ -10553,9 +10995,9 @@
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -10575,11 +11017,11 @@
       }
     },
     "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10594,9 +11036,9 @@
       "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg=="
     },
     "node_modules/hasown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -11136,6 +11578,20 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
+    "node_modules/internal-slot": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.0",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -11167,10 +11623,38 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -11181,6 +11665,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-callable": {
@@ -11195,11 +11695,44 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
+      "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "dev": true,
+      "dependencies": {
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11316,12 +11849,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-object": {
@@ -11366,6 +11926,37 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
+    "node_modules/is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -11375,12 +11966,42 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-typed-array": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
-      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+    "node_modules/is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
       "dependencies": {
-        "which-typed-array": "^1.1.11"
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "dependencies": {
+        "which-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11399,6 +12020,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-wsl": {
@@ -15345,6 +15978,55 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
+      "integrity": "sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -15823,6 +16505,14 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -17139,6 +17829,24 @@
       "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
       "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q=="
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+      "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "set-function-name": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/regexpu-core": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.2.tgz",
@@ -17248,11 +17956,11 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dependencies": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -17417,6 +18125,30 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+      "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "get-intrinsic": "^1.2.4",
+        "has-symbols": "^1.0.3",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-array-concat/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -17435,6 +18167,23 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+      "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -17780,6 +18529,21 @@
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
         "has-property-descriptors": "^1.0.2"
       },
       "engines": {
@@ -18256,6 +19020,55 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+      "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+      "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -19331,6 +20144,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -19378,6 +20212,79 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+      "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+      "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
+      "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -19393,6 +20300,21 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -20312,16 +21234,32 @@
         "which": "bin/which"
       }
     },
-    "node_modules/which-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
-      "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.4",
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -22901,6 +23839,12 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.24.tgz",
       "integrity": "sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ=="
     },
+    "@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true
+    },
     "@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -23507,6 +24451,12 @@
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
     },
     "@types/mime": {
       "version": "1.3.2",
@@ -24366,16 +25316,94 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-buffer-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.5",
+        "is-array-buffer": "^3.0.4"
+      }
+    },
     "array-flatten": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
       "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
+    },
+    "array-includes": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
+      "integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "is-string": "^1.0.7"
+      }
     },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
+    },
+    "array.prototype.findlastindex": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
+      "integrity": "sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      }
+    },
+    "array.prototype.flat": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "es-shim-unscopables": "^1.0.0"
+      }
+    },
+    "array.prototype.flatmap": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+      "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "es-shim-unscopables": "^1.0.0"
+      }
+    },
+    "arraybuffer.prototype.slice": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+      "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "dev": true,
+      "requires": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.2.1",
+        "get-intrinsic": "^1.2.3",
+        "is-array-buffer": "^3.0.4",
+        "is-shared-array-buffer": "^1.0.2"
+      }
     },
     "assert": {
       "version": "2.1.0",
@@ -24430,9 +25458,12 @@
       }
     },
     "available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "requires": {
+        "possible-typed-array-names": "^1.0.0"
+      }
     },
     "babel-jest": {
       "version": "29.7.0",
@@ -25748,6 +26779,39 @@
         "whatwg-url": "^11.0.0"
       }
     },
+    "data-view-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+      "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      }
+    },
+    "data-view-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+      "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      }
+    },
+    "data-view-byte-offset": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+      "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      }
+    },
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -26879,6 +27943,60 @@
         "stackframe": "^1.1.1"
       }
     },
+    "es-abstract": {
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
+      "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+      "dev": true,
+      "requires": {
+        "array-buffer-byte-length": "^1.0.1",
+        "arraybuffer.prototype.slice": "^1.0.3",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "data-view-buffer": "^1.0.1",
+        "data-view-byte-length": "^1.0.1",
+        "data-view-byte-offset": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-set-tostringtag": "^2.0.3",
+        "es-to-primitive": "^1.2.1",
+        "function.prototype.name": "^1.1.6",
+        "get-intrinsic": "^1.2.4",
+        "get-symbol-description": "^1.0.2",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.0.3",
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.0.7",
+        "is-array-buffer": "^3.0.4",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.1",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.3",
+        "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.13",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.13.1",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.5",
+        "regexp.prototype.flags": "^1.5.2",
+        "safe-array-concat": "^1.1.2",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.trim": "^1.2.9",
+        "string.prototype.trimend": "^1.0.8",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.2",
+        "typed-array-byte-length": "^1.0.1",
+        "typed-array-byte-offset": "^1.0.2",
+        "typed-array-length": "^1.0.6",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.15"
+      }
+    },
     "es-define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
@@ -26896,6 +28014,46 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.1.tgz",
       "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg=="
+    },
+    "es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.2.4",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.1"
+      }
+    },
+    "es-shim-unscopables": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+      "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+      "dev": true,
+      "requires": {
+        "hasown": "^2.0.0"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
     },
     "escalade": {
       "version": "3.1.1",
@@ -27239,6 +28397,100 @@
       "dev": true,
       "requires": {}
     },
+    "eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
+      "integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.30.0.tgz",
+      "integrity": "sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==",
+      "dev": true,
+      "requires": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.8",
+        "array.prototype.findlastindex": "^1.2.5",
+        "array.prototype.flat": "^1.3.2",
+        "array.prototype.flatmap": "^1.3.2",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.9.0",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.15.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.0",
+        "semver": "^6.3.1",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-prettier": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
@@ -27277,12 +28529,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true
-    },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
       "dev": true
     },
     "espree": {
@@ -27485,12 +28731,6 @@
           "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
         }
       }
-    },
-    "extensionless": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/extensionless/-/extensionless-1.9.6.tgz",
-      "integrity": "sha512-40F6zThJu1MxaT1A1pJ/2SHlU1BPYYnQNHt0j2ZlPuxxm2ddMcNc1D7uS/LGc4K3VwMEMaZLkCdHWaKk0LnQXA==",
-      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -27906,6 +29146,24 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
+    "function.prototype.name": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "functions-have-names": "^1.2.3"
+      }
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
+    },
     "fwd-stream": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/fwd-stream/-/fwd-stream-1.0.4.tgz",
@@ -27981,6 +29239,17 @@
         "pump": "^3.0.0"
       }
     },
+    "get-symbol-description": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+      "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4"
+      }
+    },
     "glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -28031,6 +29300,16 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+    },
+    "globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      }
     },
     "globby": {
       "version": "11.1.0",
@@ -28101,13 +29380,11 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
+    "has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -28123,9 +29400,9 @@
       }
     },
     "has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q=="
     },
     "has-symbols": {
       "version": "1.0.3",
@@ -28133,11 +29410,11 @@
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
     "has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "requires": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       }
     },
     "hash-sum": {
@@ -28146,9 +29423,9 @@
       "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg=="
     },
     "hasown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "requires": {
         "function-bind": "^1.1.2"
       }
@@ -28528,6 +29805,17 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
+    "internal-slot": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.0",
+        "side-channel": "^1.0.4"
+      }
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -28547,10 +29835,29 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-array-buffer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.1"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
+    "is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -28560,17 +29867,45 @@
         "binary-extensions": "^2.0.0"
       }
     },
+    "is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "requires": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
+      }
+    },
+    "is-data-view": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
+      "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "dev": true,
+      "requires": {
+        "is-typed-array": "^1.1.13"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-directory": {
@@ -28645,10 +29980,25 @@
         "define-properties": "^1.1.3"
       }
     },
+    "is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-object": {
       "version": "0.1.2",
@@ -28680,18 +30030,55 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
+    "is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-shared-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
       "dev": true
     },
-    "is-typed-array": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
-      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+    "is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
       "requires": {
-        "which-typed-array": "^1.1.11"
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "requires": {
+        "which-typed-array": "^1.1.14"
       }
     },
     "is-unicode-supported": {
@@ -28699,6 +30086,15 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
+    },
+    "is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
     },
     "is-wsl": {
       "version": "2.2.0",
@@ -31599,6 +32995,40 @@
         "object-keys": "^1.1.1"
       }
     },
+    "object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      }
+    },
+    "object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      }
+    },
+    "object.values": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
+      "integrity": "sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      }
+    },
     "obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -31957,6 +33387,11 @@
           }
         }
       }
+    },
+    "possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="
     },
     "postcss": {
       "version": "8.4.33",
@@ -32844,6 +34279,18 @@
       "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
       "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q=="
     },
+    "regexp.prototype.flags": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+      "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.6",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "set-function-name": "^2.0.1"
+      }
+    },
     "regexpu-core": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.2.tgz",
@@ -32929,11 +34376,11 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "requires": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -33035,10 +34482,41 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "safe-array-concat": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+      "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "get-intrinsic": "^1.2.4",
+        "has-symbols": "^1.0.3",
+        "isarray": "^2.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "dev": true
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safe-regex-test": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+      "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.1.4"
+      }
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -33314,6 +34792,18 @@
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      }
+    },
+    "set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "requires": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
         "has-property-descriptors": "^1.0.2"
       }
     },
@@ -33711,6 +35201,40 @@
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         }
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+      "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.0",
+        "es-object-atoms": "^1.0.0"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+      "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       }
     },
     "strip-ansi": {
@@ -34472,6 +35996,26 @@
         }
       }
     },
+    "tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+          "dev": true
+        }
+      }
+    },
     "tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -34507,6 +36051,58 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typed-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.13"
+      }
+    },
+    "typed-array-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+      "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
+      }
+    },
+    "typed-array-byte-offset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+      "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
+      }
+    },
+    "typed-array-length": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
+      "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0"
+      }
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -34516,6 +36112,18 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw=="
+    },
+    "unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -35172,16 +36780,29 @@
         "isexe": "^2.0.0"
       }
     },
-    "which-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
-      "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
       "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.4",
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "has-tostringtag": "^1.0.2"
       }
     },
     "wildcard": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:eslint:fix": "npm run test:eslint -- --fix",
     "test:stylelint": "stylelint 'src/**/*.{scss,css}' --config node_modules/do-bulma/.stylelintrc.json",
     "test:i18n-packs": "node src/nginxconfig/i18n/verify.js",
-    "test:prettier": "prettier \"src/**/*.{js,vue}\" --check",
+    "test:prettier": "prettier 'src/**/*.{js,vue}' --check",
     "test:prettier:fix": "prettier --write 'src/**/*.{js,vue}'",
     "prepare": "husky install"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:fix": "npm run test:prettier:fix && npm run test:eslint:fix",
     "test:eslint": "eslint 'src/**/*.{js,vue}' --cache",
     "test:eslint:fix": "npm run test:eslint -- --fix",
-    "test:stylelint": "stylelint 'src/**/*.{scss,css}' --config node_modules/do-bulma/.stylelintrc.json",
+    "test:stylelint": "stylelint 'src/**/*.{scss}' --config node_modules/do-bulma/.stylelintrc.json",
     "test:i18n-packs": "node src/nginxconfig/i18n/verify.js",
     "test:prettier": "prettier 'src/**/*.{js,vue}' --check",
     "test:prettier:fix": "prettier --write 'src/**/*.{js,vue}'",
@@ -100,7 +100,7 @@
     "@vue/cli-service": {
       "mini-css-extract-plugin": "^1.6.2",
       "@achrinza/node-ipc": "^10.1.10"
-  },
+    },
     "pretty-checkbox-vue": {
       "vue": "^3.0.0"
     }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:fix": "npm run test:prettier:fix && npm run test:eslint:fix",
     "test:eslint": "eslint 'src/**/*.{js,vue}' --cache",
     "test:eslint:fix": "npm run test:eslint -- --fix",
-    "test:stylelint": "stylelint 'src/**/*.{scss}' --config node_modules/do-bulma/.stylelintrc.json",
+    "test:stylelint": "stylelint 'src/**/*.scss' --config node_modules/do-bulma/.stylelintrc.json",
     "test:i18n-packs": "node src/nginxconfig/i18n/verify.js",
     "test:prettier": "prettier 'src/**/*.{js,vue}' --check",
     "test:prettier:fix": "prettier --write 'src/**/*.{js,vue}'",

--- a/package.json
+++ b/package.json
@@ -1,107 +1,108 @@
 {
-  "name": "nginxconfig.io",
-  "version": "1.0.0",
-  "description": "NGINX config generator on steroids",
-  "license": "MIT",
-  "private": true,
-  "engines": {
-    "node": "20.9.0"
-  },
-  "main": "src/nginxconfig/mount.js",
-  "type": "module",
-  "scripts": {
-    "build": "npm run build:clean && npm run build:template && npm run build:prism && npm run build:static && npm run build:tool",
-    "build:clean": "do-vue clean",
-    "build:template": "do-vue template && node src/nginxconfig/build/template.js",
-    "build:prism": "node src/nginxconfig/build/prism.js",
-    "build:static": "copyfiles --up 2 src/static/{*,**/*} dist",
-    "build:tool": "vue-cli-service build src/nginxconfig/mount.js --no-clean",
-    "dev": "npm run build:template && npm run build:prism && npm run dev:tool",
-    "dev:tool": "vue-cli-service serve src/nginxconfig/mount.js",
-    "deploy:spaces:comment": "do-vue comment nginxconfig",
-    "test": "npm run test:prettier:fix && npm run test:eslint && npm run test:stylelint && npm run test:i18n-packs && npm run test:jest",
-    "test:jest": "jest --env=jsdom /test/.*.js?$",
-    "test:fix": "npm run test:prettier:fix && npm run test:eslint:fix",
-    "test:eslint": "eslint 'src/**/*.{js,vue}' --cache",
-    "test:eslint:fix": "npm run test:eslint -- --fix",
-    "test:stylelint": "stylelint 'src/**/*.scss' --config node_modules/do-bulma/.stylelintrc.json",
-    "test:i18n-packs": "node --import=extensionless/register src/nginxconfig/i18n/verify.js",
-    "test:prettier": "prettier 'src/**/*.{js,vue}' --check",
-    "test:prettier:fix": "prettier --write 'src/**/*.{js,vue}'",
-    "prepare": "husky install"
-  },
-  "jest": {
-    "testRegex": "/test/.*.js?$"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/digitalocean/nginxconfig.io.git"
-  },
-  "keywords": [
-    "nginx"
-  ],
-  "author": "DigitalOcean",
-  "bugs": {
-    "url": "https://github.com/digitalocean/nginxconfig.io/issues"
-  },
-  "homepage": "https://github.com/digitalocean/nginxconfig.io#readme",
-  "dependencies": {
-    "clipboard": "^2.0.11",
-    "clone": "^2.1.2",
-    "do-bulma": "github:do-community/do-bulma",
-    "do-vue": "github:do-community/do-vue",
-    "escape-html": "^1.0.3",
-    "files-diff": "0.0.6",
-    "json-to-pretty-yaml": "^1.2.2",
-    "memory-tar-create": "0.0.3",
-    "pretty-checkbox-vue": "^1.1.9",
-    "prismjs": "^1.29.0",
-    "qs": "^6.11.2",
-    "simple-js-sha2-256": "^1.0.7",
-    "vue": "^3.4.15",
-    "vue-i18n": "^9.9.0",
-    "vue-select": "^4.0.0-beta.6",
-    "webpack-require-from": "^1.8.6"
-  },
-  "devDependencies": {
-    "@babel/eslint-parser": "^7.23.3",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-transform-runtime": "^7.23.7",
-    "@babel/preset-env": "^7.23.8",
-    "@babel/runtime": "^7.23.8",
-    "@vue/cli-service": "^5.0.8",
-    "ajv": "^8.12.0",
-    "chalk": "^5.3.0",
-    "copyfiles": "^2.4.1",
-    "core-js": "^3.35.1",
-    "duplicate-package-checker-webpack-plugin": "^3.0.0",
-    "eslint": "^8.56.0",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-prettier": "^5.1.3",
-    "eslint-plugin-vue": "^9.20.1",
-    "husky": "^8.0.3",
-    "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0",
-    "lint-staged": "^15.2.10",
-    "node-fetch": "^3.3.2",
-    "postcss": "^8.4.33",
-    "prettier": "3.2.4",
-    "sass": "^1.70.0",
-    "sass-loader": "^14.0.0",
-    "stylelint": "^16.2.0",
-    "stylelint-config-standard-scss": "^13.0.0",
-    "stylelint-order": "^6.0.4",
-    "vue-template-compiler": "^2.7.16",
-    "webpack": "^5.94.0",
-    "webpack-bundle-analyzer": "^4.10.1"
-  },
-  "overrides": {
-    "@vue/cli-service": {
-      "mini-css-extract-plugin": "^1.6.2",
-      "@achrinza/node-ipc": "^10.1.10"
-    },
-    "pretty-checkbox-vue": {
-      "vue": "^3.0.0"
-    }
-  }
+	"name": "nginxconfig.io",
+	"version": "1.0.0",
+	"description": "NGINX config generator on steroids",
+	"license": "MIT",
+	"private": true,
+	"engines": {
+		"node": "20.9.0"
+	},
+	"main": "src/nginxconfig/mount.js",
+	"type": "module",
+	"scripts": {
+		"build": "npm run build:clean && npm run build:template && npm run build:prism && npm run build:static && npm run build:tool",
+		"build:clean": "do-vue clean",
+		"build:template": "do-vue template && node src/nginxconfig/build/template.js",
+		"build:prism": "node src/nginxconfig/build/prism.js",
+		"build:static": "copyfiles --up 2 src/static/{*,**/*} dist",
+		"build:tool": "vue-cli-service build src/nginxconfig/mount.js --no-clean",
+		"dev": "npm run build:template && npm run build:prism && npm run dev:tool",
+		"dev:tool": "vue-cli-service serve src/nginxconfig/mount.js",
+		"deploy:spaces:comment": "do-vue comment nginxconfig",
+		"test": "npm run test:prettier:fix && npm run test:eslint && npm run test:stylelint && npm run test:i18n-packs && npm run test:jest",
+		"test:jest": "jest --env=jsdom /test/.*.js?$",
+		"test:fix": "npm run test:prettier:fix && npm run test:eslint:fix",
+		"test:eslint": "eslint src/**/*.{js,vue} --cache",
+		"test:eslint:fix": "npm run test:eslint -- --fix",
+		"test:stylelint": "stylelint 'src/**/*.{scss,css}' --config node_modules/do-bulma/.stylelintrc.json",
+		"test:i18n-packs": "node src/nginxconfig/i18n/verify.js",
+		"test:prettier": "prettier 'src/**/*.{js,vue}' --check",
+		"test:prettier:fix": "prettier --write 'src/**/*.{js,vue}'",
+		"prepare": "husky install"
+	},
+	"jest": {
+		"testRegex": "/test/.*.js?$"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/digitalocean/nginxconfig.io.git"
+	},
+	"keywords": [
+		"nginx"
+	],
+	"author": "DigitalOcean",
+	"bugs": {
+		"url": "https://github.com/digitalocean/nginxconfig.io/issues"
+	},
+	"homepage": "https://github.com/digitalocean/nginxconfig.io#readme",
+	"dependencies": {
+		"clipboard": "^2.0.11",
+		"clone": "^2.1.2",
+		"do-bulma": "github:do-community/do-bulma",
+		"do-vue": "github:do-community/do-vue",
+		"escape-html": "^1.0.3",
+		"files-diff": "0.0.6",
+		"json-to-pretty-yaml": "^1.2.2",
+		"memory-tar-create": "0.0.3",
+		"pretty-checkbox-vue": "^1.1.9",
+		"prismjs": "^1.29.0",
+		"qs": "^6.11.2",
+		"simple-js-sha2-256": "^1.0.7",
+		"vue": "^3.4.15",
+		"vue-i18n": "^9.9.0",
+		"vue-select": "^4.0.0-beta.6",
+		"webpack-require-from": "^1.8.6"
+	},
+	"devDependencies": {
+		"@babel/eslint-parser": "^7.23.3",
+		"@babel/plugin-proposal-class-properties": "^7.18.6",
+		"@babel/plugin-transform-runtime": "^7.23.7",
+		"@babel/preset-env": "^7.23.8",
+		"@babel/runtime": "^7.23.8",
+		"@vue/cli-service": "^5.0.8",
+		"ajv": "^8.12.0",
+		"chalk": "^5.3.0",
+		"copyfiles": "^2.4.1",
+		"core-js": "^3.35.1",
+		"duplicate-package-checker-webpack-plugin": "^3.0.0",
+		"eslint": "^8.56.0",
+		"eslint-config-prettier": "^9.1.0",
+		"eslint-plugin-import": "^2.30.0",
+		"eslint-plugin-prettier": "^5.1.3",
+		"eslint-plugin-vue": "^9.20.1",
+		"husky": "^8.0.3",
+		"jest": "^29.7.0",
+		"jest-environment-jsdom": "^29.7.0",
+		"lint-staged": "^15.2.10",
+		"node-fetch": "^3.3.2",
+		"postcss": "^8.4.33",
+		"prettier": "3.2.4",
+		"sass": "^1.70.0",
+		"sass-loader": "^14.0.0",
+		"stylelint": "^16.2.0",
+		"stylelint-config-standard-scss": "^13.0.0",
+		"stylelint-order": "^6.0.4",
+		"vue-template-compiler": "^2.7.16",
+		"webpack": "^5.94.0",
+		"webpack-bundle-analyzer": "^4.10.1"
+	},
+	"overrides": {
+		"@vue/cli-service": {
+			"mini-css-extract-plugin": "^1.6.2",
+			"@achrinza/node-ipc": "^10.1.10"
+		},
+		"pretty-checkbox-vue": {
+			"vue": "^3.0.0"
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,108 +1,108 @@
 {
   "name": "nginxconfig.io",
-	"version": "1.0.0",
-	"description": "NGINX config generator on steroids",
-	"license": "MIT",
-	"private": true,
-	"engines": {
-		"node": "20.9.0"
-	},
-	"main": "src/nginxconfig/mount.js",
-	"type": "module",
-	"scripts": {
-		"build": "npm run build:clean && npm run build:template && npm run build:prism && npm run build:static && npm run build:tool",
-		"build:clean": "do-vue clean",
-		"build:template": "do-vue template && node src/nginxconfig/build/template.js",
-		"build:prism": "node src/nginxconfig/build/prism.js",
-		"build:static": "copyfiles --up 2 src/static/{*,**/*} dist",
-		"build:tool": "vue-cli-service build src/nginxconfig/mount.js --no-clean",
-		"dev": "npm run build:template && npm run build:prism && npm run dev:tool",
-		"dev:tool": "vue-cli-service serve src/nginxconfig/mount.js",
-		"deploy:spaces:comment": "do-vue comment nginxconfig",
-		"test": "npm run test:prettier:fix && npm run test:eslint && npm run test:stylelint && npm run test:i18n-packs && npm run test:jest",
-		"test:jest": "jest --env=jsdom /test/.*.js?$",
-		"test:fix": "npm run test:prettier:fix && npm run test:eslint:fix",
-		"test:eslint": "eslint src/**/*.{js,vue} --cache",
-		"test:eslint:fix": "npm run test:eslint -- --fix",
-		"test:stylelint": "stylelint 'src/**/*.{scss,css}' --config node_modules/do-bulma/.stylelintrc.json",
-		"test:i18n-packs": "node src/nginxconfig/i18n/verify.js",
-		"test:prettier": "prettier 'src/**/*.{js,vue}' --check",
-		"test:prettier:fix": "prettier --write 'src/**/*.{js,vue}'",
-		"prepare": "husky install"
-	},
-	"jest": {
-		"testRegex": "/test/.*.js?$"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/digitalocean/nginxconfig.io.git"
-	},
-	"keywords": [
-		"nginx"
-	],
-	"author": "DigitalOcean",
-	"bugs": {
-		"url": "https://github.com/digitalocean/nginxconfig.io/issues"
-	},
-	"homepage": "https://github.com/digitalocean/nginxconfig.io#readme",
-	"dependencies": {
-		"clipboard": "^2.0.11",
-		"clone": "^2.1.2",
-		"do-bulma": "github:do-community/do-bulma",
-		"do-vue": "github:do-community/do-vue",
-		"escape-html": "^1.0.3",
-		"files-diff": "0.0.6",
-		"json-to-pretty-yaml": "^1.2.2",
-		"memory-tar-create": "0.0.3",
-		"pretty-checkbox-vue": "^1.1.9",
-		"prismjs": "^1.29.0",
-		"qs": "^6.11.2",
-		"simple-js-sha2-256": "^1.0.7",
-		"vue": "^3.4.15",
-		"vue-i18n": "^9.9.0",
-		"vue-select": "^4.0.0-beta.6",
-		"webpack-require-from": "^1.8.6"
-	},
-	"devDependencies": {
-		"@babel/eslint-parser": "^7.23.3",
-		"@babel/plugin-proposal-class-properties": "^7.18.6",
-		"@babel/plugin-transform-runtime": "^7.23.7",
-		"@babel/preset-env": "^7.23.8",
-		"@babel/runtime": "^7.23.8",
-		"@vue/cli-service": "^5.0.8",
-		"ajv": "^8.12.0",
-		"chalk": "^5.3.0",
-		"copyfiles": "^2.4.1",
-		"core-js": "^3.35.1",
-		"duplicate-package-checker-webpack-plugin": "^3.0.0",
-		"eslint": "^8.56.0",
-		"eslint-config-prettier": "^9.1.0",
-		"eslint-plugin-import": "^2.30.0",
-		"eslint-plugin-prettier": "^5.1.3",
-		"eslint-plugin-vue": "^9.20.1",
-		"husky": "^8.0.3",
-		"jest": "^29.7.0",
-		"jest-environment-jsdom": "^29.7.0",
-		"lint-staged": "^15.2.10",
-		"node-fetch": "^3.3.2",
-		"postcss": "^8.4.33",
-		"prettier": "3.2.4",
-		"sass": "^1.70.0",
-		"sass-loader": "^14.0.0",
-		"stylelint": "^16.2.0",
-		"stylelint-config-standard-scss": "^13.0.0",
-		"stylelint-order": "^6.0.4",
-		"vue-template-compiler": "^2.7.16",
-		"webpack": "^5.94.0",
-		"webpack-bundle-analyzer": "^4.10.1"
-	},
-	"overrides": {
-		"@vue/cli-service": {
-			"mini-css-extract-plugin": "^1.6.2",
-			"@achrinza/node-ipc": "^10.1.10"
-		},
-		"pretty-checkbox-vue": {
-			"vue": "^3.0.0"
-		}
-	}
+  "version": "1.0.0",
+  "description": "NGINX config generator on steroids",
+  "license": "MIT",
+  "private": true,
+  "engines": {
+    "node": "20.9.0"
+  },
+  "main": "src/nginxconfig/mount.js",
+  "type": "module",
+  "scripts": {
+    "build": "npm run build:clean && npm run build:template && npm run build:prism && npm run build:static && npm run build:tool",
+    "build:clean": "do-vue clean",
+    "build:template": "do-vue template && node src/nginxconfig/build/template.js",
+    "build:prism": "node src/nginxconfig/build/prism.js",
+    "build:static": "copyfiles --up 2 src/static/{*,**/*} dist",
+    "build:tool": "vue-cli-service build src/nginxconfig/mount.js --no-clean",
+    "dev": "npm run build:template && npm run build:prism && npm run dev:tool",
+    "dev:tool": "vue-cli-service serve src/nginxconfig/mount.js",
+    "deploy:spaces:comment": "do-vue comment nginxconfig",
+    "test": "npm run test:prettier:fix && npm run test:eslint && npm run test:stylelint && npm run test:i18n-packs && npm run test:jest",
+    "test:jest": "jest --env=jsdom /test/.*.js?$",
+    "test:fix": "npm run test:prettier:fix && npm run test:eslint:fix",
+    "test:eslint": "eslint src/**/*.{js,vue} --cache",
+    "test:eslint:fix": "npm run test:eslint -- --fix",
+    "test:stylelint": "stylelint 'src/**/*.{scss,css}' --config node_modules/do-bulma/.stylelintrc.json",
+    "test:i18n-packs": "node src/nginxconfig/i18n/verify.js",
+    "test:prettier": "prettier 'src/**/*.{js,vue}' --check",
+    "test:prettier:fix": "prettier --write 'src/**/*.{js,vue}'",
+    "prepare": "husky install"
+  },
+  "jest": {
+    "testRegex": "/test/.*.js?$"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/digitalocean/nginxconfig.io.git"
+  },
+  "keywords": [
+    "nginx"
+  ],
+  "author": "DigitalOcean",
+  "bugs": {
+    "url": "https://github.com/digitalocean/nginxconfig.io/issues"
+  },
+  "homepage": "https://github.com/digitalocean/nginxconfig.io#readme",
+  "dependencies": {
+    "clipboard": "^2.0.11",
+    "clone": "^2.1.2",
+    "do-bulma": "github:do-community/do-bulma",
+    "do-vue": "github:do-community/do-vue",
+    "escape-html": "^1.0.3",
+    "files-diff": "0.0.6",
+    "json-to-pretty-yaml": "^1.2.2",
+    "memory-tar-create": "0.0.3",
+    "pretty-checkbox-vue": "^1.1.9",
+    "prismjs": "^1.29.0",
+    "qs": "^6.11.2",
+    "simple-js-sha2-256": "^1.0.7",
+    "vue": "^3.4.15",
+    "vue-i18n": "^9.9.0",
+    "vue-select": "^4.0.0-beta.6",
+    "webpack-require-from": "^1.8.6"
+  },
+  "devDependencies": {
+    "@babel/eslint-parser": "^7.23.3",
+    "@babel/plugin-proposal-class-properties": "^7.18.6",
+    "@babel/plugin-transform-runtime": "^7.23.7",
+    "@babel/preset-env": "^7.23.8",
+    "@babel/runtime": "^7.23.8",
+    "@vue/cli-service": "^5.0.8",
+    "ajv": "^8.12.0",
+    "chalk": "^5.3.0",
+    "copyfiles": "^2.4.1",
+    "core-js": "^3.35.1",
+    "duplicate-package-checker-webpack-plugin": "^3.0.0",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.30.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "eslint-plugin-vue": "^9.20.1",
+    "husky": "^8.0.3",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "lint-staged": "^15.2.10",
+    "node-fetch": "^3.3.2",
+    "postcss": "^8.4.33",
+    "prettier": "3.2.4",
+    "sass": "^1.70.0",
+    "sass-loader": "^14.0.0",
+    "stylelint": "^16.2.0",
+    "stylelint-config-standard-scss": "^13.0.0",
+    "stylelint-order": "^6.0.4",
+    "vue-template-compiler": "^2.7.16",
+    "webpack": "^5.94.0",
+    "webpack-bundle-analyzer": "^4.10.1"
+  },
+  "overrides": {
+    "@vue/cli-service": {
+    "mini-css-extract-plugin": "^1.6.2",
+    "@achrinza/node-ipc": "^10.1.10"
+  },
+    "pretty-checkbox-vue": {
+    "vue": "^3.0.0"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "test": "npm run test:prettier:fix && npm run test:eslint && npm run test:stylelint && npm run test:i18n-packs && npm run test:jest",
     "test:jest": "jest --env=jsdom /test/.*.js?$",
     "test:fix": "npm run test:prettier:fix && npm run test:eslint:fix",
-    "test:eslint": "eslint src/**/*.{js,vue} --cache",
+    "test:eslint": "eslint 'src/**/*.{js,vue}' --cache",
     "test:eslint:fix": "npm run test:eslint -- --fix",
     "test:stylelint": "stylelint 'src/**/*.{scss,css}' --config node_modules/do-bulma/.stylelintrc.json",
     "test:i18n-packs": "node src/nginxconfig/i18n/verify.js",
-    "test:prettier": "prettier 'src/**/*.{js,vue}' --check",
+    "test:prettier": "prettier \"src/**/*.{js,vue}\" --check",
     "test:prettier:fix": "prettier --write 'src/**/*.{js,vue}'",
     "prepare": "husky install"
   },
@@ -98,11 +98,11 @@
   },
   "overrides": {
     "@vue/cli-service": {
-    "mini-css-extract-plugin": "^1.6.2",
-    "@achrinza/node-ipc": "^10.1.10"
+      "mini-css-extract-plugin": "^1.6.2",
+      "@achrinza/node-ipc": "^10.1.10"
   },
     "pretty-checkbox-vue": {
-    "vue": "^3.0.0"
+      "vue": "^3.0.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "nginxconfig.io",
+  "name": "nginxconfig.io",
 	"version": "1.0.0",
 	"description": "NGINX config generator on steroids",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -79,8 +79,6 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-vue": "^9.20.1",
-    "esm": "^3.2.25",
-    "extensionless": "^1.9.6",
     "husky": "^8.0.3",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/src/nginxconfig/build/webpack-dynamic-import.js
+++ b/src/nginxconfig/build/webpack-dynamic-import.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { info } from '../util/log';
+import { info } from '../util/log.js';
 
 const originalSrcDir = document.currentScript.src.split('/').slice(0, -2).join('/') + '/';
 window.__webpackDynamicImportURL = () => {

--- a/src/nginxconfig/build/webpack-dynamic-import.js
+++ b/src/nginxconfig/build/webpack-dynamic-import.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/generators/conf/general.conf.js
+++ b/src/nginxconfig/generators/conf/general.conf.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/generators/conf/general.conf.js
+++ b/src/nginxconfig/generators/conf/general.conf.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { gzipTypes, extensions } from '../../util/types_extensions';
+import { gzipTypes, extensions } from '../../util/types_extensions.js';
 
 export default (domains, global) => {
     const config = {};

--- a/src/nginxconfig/generators/conf/nginx.conf.js
+++ b/src/nginxconfig/generators/conf/nginx.conf.js
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { errorLogPathDisabled } from '../../util/logging';
-import sslProfiles from '../../util/ssl_profiles';
-import websiteConf from './website.conf';
+import { errorLogPathDisabled } from '../../util/logging.js';
+import sslProfiles from '../../util/ssl_profiles.js';
+import websiteConf from './website.conf.js';
 
 export default (domains, global) => {
     const config = {};

--- a/src/nginxconfig/generators/conf/nginx.conf.js
+++ b/src/nginxconfig/generators/conf/nginx.conf.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/generators/conf/security.conf.js
+++ b/src/nginxconfig/generators/conf/security.conf.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import commonHsts from '../../util/common_hsts';
+import commonHsts from '../../util/common_hsts.js';
 
 export default (domains, global) => {
     const config = [];

--- a/src/nginxconfig/generators/conf/security.conf.js
+++ b/src/nginxconfig/generators/conf/security.conf.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -24,22 +24,22 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { getSslCertificate, getSslCertificateKey } from '../../util/get_ssl_certificate';
-import { extensions, gzipTypes } from '../../util/types_extensions';
-import { getDomainAccessLog, getDomainErrorLog } from '../../util/logging';
-import commonHsts from '../../util/common_hsts';
-import securityConf from './security.conf';
-import pythonConf from './python_uwsgi.conf';
-import proxyConf from './proxy.conf';
-import phpConf from './php_fastcgi.conf';
-import generalConf from './general.conf';
-import wordPressConf from './wordpress.conf';
-import drupalConf from './drupal.conf';
-import magentoConf from './magento.conf';
-import joomlaConf from './joomla.conf';
-import letsEncryptConf from './letsencrypt.conf';
-import phpPath from '../../util/php_path';
-import phpUpstream from '../../util/php_upstream';
+import { getSslCertificate, getSslCertificateKey } from '../../util/get_ssl_certificate.js';
+import { extensions, gzipTypes } from '../../util/types_extensions.js';
+import { getDomainAccessLog, getDomainErrorLog } from '../../util/logging.js';
+import commonHsts from '../../util/common_hsts.js';
+import securityConf from './security.conf.js';
+import pythonConf from './python_uwsgi.conf.js';
+import proxyConf from './proxy.conf.js';
+import phpConf from './php_fastcgi.conf.js';
+import generalConf from './general.conf.js';
+import wordPressConf from './wordpress.conf.js';
+import drupalConf from './drupal.conf.js';
+import magentoConf from './magento.conf.js';
+import joomlaConf from './joomla.conf.js';
+import letsEncryptConf from './letsencrypt.conf.js';
+import phpPath from '../../util/php_path.js';
+import phpUpstream from '../../util/php_upstream.js';
 
 const sslConfig = (domain, global) => {
     const config = [];

--- a/src/nginxconfig/generators/conf/website.conf.js
+++ b/src/nginxconfig/generators/conf/website.conf.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/generators/conf/wordpress.conf.js
+++ b/src/nginxconfig/generators/conf/wordpress.conf.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import phpPath from '../../util/php_path';
-import phpUpstream from '../../util/php_upstream';
+import phpPath from '../../util/php_path.js';
+import phpUpstream from '../../util/php_upstream.js';
 
 export default (global, domain) => {
     const config = {};

--- a/src/nginxconfig/generators/conf/wordpress.conf.js
+++ b/src/nginxconfig/generators/conf/wordpress.conf.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/generators/index.js
+++ b/src/nginxconfig/generators/index.js
@@ -24,23 +24,23 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import toConf from './to_conf';
-import toYaml from './to_yaml';
-import nginxConf from './conf/nginx.conf';
-import websiteConf from './conf/website.conf';
-import letsEncryptConf from './conf/letsencrypt.conf';
-import securityConf from './conf/security.conf';
-import generalConf from './conf/general.conf';
-import phpConf from './conf/php_fastcgi.conf';
-import pythonConf from './conf/python_uwsgi.conf';
-import proxyConf from './conf/proxy.conf';
-import wordPressConf from './conf/wordpress.conf';
-import drupalConf from './conf/drupal.conf';
-import magentoConf from './conf/magento.conf';
-import joomlaConf from './conf/joomla.conf';
-import dockerComposeYaml from './yaml/dockerCompose.yaml';
-import dockerConf from './ext/docker';
-import shareQuery from '../util/share_query';
+import toConf from './to_conf.js';
+import toYaml from './to_yaml.js';
+import nginxConf from './conf/nginx.conf.js';
+import websiteConf from './conf/website.conf.js';
+import letsEncryptConf from './conf/letsencrypt.conf.js';
+import securityConf from './conf/security.conf.js';
+import generalConf from './conf/general.conf.js';
+import phpConf from './conf/php_fastcgi.conf.js';
+import pythonConf from './conf/python_uwsgi.conf.js';
+import proxyConf from './conf/proxy.conf.js';
+import wordPressConf from './conf/wordpress.conf.js';
+import drupalConf from './conf/drupal.conf.js';
+import magentoConf from './conf/magento.conf.js';
+import joomlaConf from './conf/joomla.conf.js';
+import dockerComposeYaml from './yaml/dockerCompose.yaml.js';
+import dockerConf from './ext/docker.js';
+import shareQuery from '../util/share_query.js';
 
 export default (domains, global) => {
     const files = {};

--- a/src/nginxconfig/generators/index.js
+++ b/src/nginxconfig/generators/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/generators/to_conf.js
+++ b/src/nginxconfig/generators/to_conf.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import isObject from '../util/is_object';
+import isObject from '../util/is_object.js';
 
 const isBlock = (item) => {
     // If an object, or kv entries, this is considered a block

--- a/src/nginxconfig/generators/to_conf.js
+++ b/src/nginxconfig/generators/to_conf.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/index.js
+++ b/src/nginxconfig/i18n/de/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/de/index.js
+++ b/src/nginxconfig/i18n/de/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -26,6 +26,6 @@ THE SOFTWARE.
 
 import common from './common.js';
 import languages from './languages.js';
-import templates from './templates';
+import templates from './templates/index.js';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/de/templates/app.js
+++ b/src/nginxconfig/i18n/de/templates/app.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../common';
+import common from '../common.js';
 
 export default {
     title: `${common.nginx}Config`,

--- a/src/nginxconfig/i18n/de/templates/app.js
+++ b/src/nginxconfig/i18n/de/templates/app.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/de/templates/callouts/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/de/templates/callouts/index.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import droplet from './droplet';
-import contribute from './contribute';
+import droplet from './droplet.js';
+import contribute from './contribute.js';
 
 export default { droplet, contribute };

--- a/src/nginxconfig/i18n/de/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/https.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableEncryptedSslConnection: `${common.enable} verschlüsselte ${common.ssl} Verbindungen`,

--- a/src/nginxconfig/i18n/de/templates/domain_sections/index.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/domain_sections/index.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/index.js
@@ -24,16 +24,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import onion from './onion';
-import php from './php';
-import presets from './presets';
-import python from './python';
-import restrict from './restrict';
-import reverseProxy from './reverse_proxy';
-import routing from './routing';
-import server from './server';
+import https from './https.js';
+import logging from './logging.js';
+import onion from './onion.js';
+import php from './php.js';
+import presets from './presets.js';
+import python from './python.js';
+import restrict from './restrict.js';
+import reverseProxy from './reverse_proxy.js';
+import routing from './routing.js';
+import server from './server.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/de/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/php.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     phpIsDisabled: `${common.php} ist deaktiviert.`,

--- a/src/nginxconfig/i18n/de/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/domain_sections/python.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/python.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonIsDisabled: `${common.python} ist deaktiviert.`,

--- a/src/nginxconfig/i18n/de/templates/domain_sections/python.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/domain_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/reverse_proxy.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     reverseProxyIsDisabled: `${common.reverseProxy} ist deaktiviert.`,

--- a/src/nginxconfig/i18n/de/templates/domain_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/domain_sections/routing.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/routing.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     fallbackRouting: 'Fallback Routing',

--- a/src/nginxconfig/i18n/de/templates/domain_sections/routing.js
+++ b/src/nginxconfig/i18n/de/templates/domain_sections/routing.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/global_sections/docker.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/docker.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/global_sections/docker.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/docker.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const docker = 'Docker';
 const dockerfile = 'Dockerfile';

--- a/src/nginxconfig/i18n/de/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/https.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const mozilla = 'Mozilla';
 const ipv4 = 'IPv4';

--- a/src/nginxconfig/i18n/de/templates/global_sections/index.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/global_sections/index.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/index.js
@@ -24,15 +24,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import nginx from './nginx';
-import performance from './performance';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import security from './security';
-import tools from './tools';
-import docker from './docker';
+import https from './https.js';
+import logging from './logging.js';
+import nginx from './nginx.js';
+import performance from './performance.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import security from './security.js';
+import tools from './tools.js';
+import docker from './docker.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/de/templates/global_sections/logging.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/global_sections/logging.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/logging.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableFileNotFoundErrorLogging: `${common.enable} "Seite nicht gefunden" Error Logging in`,

--- a/src/nginxconfig/i18n/de/templates/global_sections/nginx.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/nginx.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/global_sections/nginx.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/nginx.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     nginxConfigDirectory: `${common.nginx} Konfigurationsverzeichnis`,

--- a/src/nginxconfig/i18n/de/templates/global_sections/performance.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/performance.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     disableHtmlCaching: 'Disable HTML caching', // TODO: translate

--- a/src/nginxconfig/i18n/de/templates/global_sections/performance.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/performance.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/global_sections/python.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/global_sections/python.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/python.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonServer: `${common.python} Server`,

--- a/src/nginxconfig/i18n/de/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/reverse_proxy.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const legacyXForwarded = 'Legacy X-Forwarded-* Header';
 

--- a/src/nginxconfig/i18n/de/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/security.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/security.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `Bei der Verwendung von ${common.wordPress} ist es oft nötig, <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code> in die Content Security Policy aufzunehmen, damit der Admin-Bereich korrekt funktioniert.`,

--- a/src/nginxconfig/i18n/de/templates/global_sections/tools.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/tools.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     modularizedStructure: 'Modularisierte Struktur',

--- a/src/nginxconfig/i18n/de/templates/global_sections/tools.js
+++ b/src/nginxconfig/i18n/de/templates/global_sections/tools.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/index.js
+++ b/src/nginxconfig/i18n/de/templates/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -27,9 +27,9 @@ THE SOFTWARE.
 import app from './app.js';
 import setup from './setup.js';
 import footer from './footer.js';
-import domainSections from './domain_sections';
-import globalSections from './global_sections';
-import setupSections from './setup_sections';
-import callouts from './callouts';
+import domainSections from './domain_sections/index.js';
+import globalSections from './global_sections/index.js';
+import setupSections from './setup_sections/index.js';
+import callouts from './callouts/index.js';
 
 export default { app, setup, footer, domainSections, globalSections, setupSections, callouts };

--- a/src/nginxconfig/i18n/de/templates/index.js
+++ b/src/nginxconfig/i18n/de/templates/index.js
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import app from './app';
-import setup from './setup';
-import footer from './footer';
+import app from './app.js';
+import setup from './setup.js';
+import footer from './footer.js';
 import domainSections from './domain_sections';
 import globalSections from './global_sections';
 import setupSections from './setup_sections';

--- a/src/nginxconfig/i18n/de/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/de/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/de/templates/setup_sections/certbot.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const certbot = 'Certbot';
 

--- a/src/nginxconfig/i18n/de/templates/setup_sections/download.js
+++ b/src/nginxconfig/i18n/de/templates/setup_sections/download.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/setup_sections/download.js
+++ b/src/nginxconfig/i18n/de/templates/setup_sections/download.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     downloadTheGeneratedConfig: 'Generierte Konfigurationsdateien <b>herunterladen</b>:',

--- a/src/nginxconfig/i18n/de/templates/setup_sections/go_live.js
+++ b/src/nginxconfig/i18n/de/templates/setup_sections/go_live.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     letsGoLive: 'Jetzt gehts los!',

--- a/src/nginxconfig/i18n/de/templates/setup_sections/go_live.js
+++ b/src/nginxconfig/i18n/de/templates/setup_sections/go_live.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/setup_sections/index.js
+++ b/src/nginxconfig/i18n/de/templates/setup_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/de/templates/setup_sections/index.js
+++ b/src/nginxconfig/i18n/de/templates/setup_sections/index.js
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import certbot from './certbot';
-import download from './download';
-import goLive from './go_live';
-import ssl from './ssl';
+import certbot from './certbot.js';
+import download from './download.js';
+import goLive from './go_live.js';
+import ssl from './ssl.js';
 
 export default { certbot, download, goLive, ssl };

--- a/src/nginxconfig/i18n/de/templates/setup_sections/ssl.js
+++ b/src/nginxconfig/i18n/de/templates/setup_sections/ssl.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     generateDiffieHellmanKeysByRunningThisCommandOnYourServer:

--- a/src/nginxconfig/i18n/de/templates/setup_sections/ssl.js
+++ b/src/nginxconfig/i18n/de/templates/setup_sections/ssl.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/en/index.js
+++ b/src/nginxconfig/i18n/en/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -26,6 +26,6 @@ THE SOFTWARE.
 
 import common from './common.js';
 import languages from './languages.js';
-import templates from './templates';
+import templates from './templates/index.js';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/en/index.js
+++ b/src/nginxconfig/i18n/en/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/en/templates/app.js
+++ b/src/nginxconfig/i18n/en/templates/app.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../common';
+import common from '../common.js';
 
 export default {
     title: `${common.nginx}Config`,

--- a/src/nginxconfig/i18n/en/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/en/templates/callouts/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import droplet from './droplet';
-import contribute from './contribute';
+import droplet from './droplet.js';
+import contribute from './contribute.js';
 
 export default { droplet, contribute };

--- a/src/nginxconfig/i18n/en/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/en/templates/domain_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/en/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/en/templates/domain_sections/https.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableEncryptedSslConnection: `${common.enable} encrypted ${common.ssl} connections`,

--- a/src/nginxconfig/i18n/en/templates/domain_sections/index.js
+++ b/src/nginxconfig/i18n/en/templates/domain_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,16 +24,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import php from './php';
-import presets from './presets';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import routing from './routing';
-import server from './server';
-import restrict from './restrict';
-import onion from './onion';
+import https from './https.js';
+import logging from './logging.js';
+import php from './php.js';
+import presets from './presets.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import routing from './routing.js';
+import server from './server.js';
+import restrict from './restrict.js';
+import onion from './onion.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/en/templates/domain_sections/logging.js
+++ b/src/nginxconfig/i18n/en/templates/domain_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     byDomain: 'by domain',

--- a/src/nginxconfig/i18n/en/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/en/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     phpIsDisabled: `${common.php} is disabled.`,

--- a/src/nginxconfig/i18n/en/templates/domain_sections/python.js
+++ b/src/nginxconfig/i18n/en/templates/domain_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonIsDisabled: `${common.python} is disabled.`,

--- a/src/nginxconfig/i18n/en/templates/domain_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/en/templates/domain_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     reverseProxyIsDisabled: `${common.reverseProxy} is disabled.`,

--- a/src/nginxconfig/i18n/en/templates/domain_sections/routing.js
+++ b/src/nginxconfig/i18n/en/templates/domain_sections/routing.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     fallbackRouting: 'Fallback routing',

--- a/src/nginxconfig/i18n/en/templates/global_sections/docker.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/docker.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const docker = 'Docker';
 const dockerfile = 'Dockerfile';

--- a/src/nginxconfig/i18n/en/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const mozilla = 'Mozilla';
 const ipv4 = 'IPv4';

--- a/src/nginxconfig/i18n/en/templates/global_sections/index.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,15 +24,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import nginx from './nginx';
-import performance from './performance';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import security from './security';
-import tools from './tools';
-import docker from './docker';
+import https from './https.js';
+import logging from './logging.js';
+import nginx from './nginx.js';
+import performance from './performance.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import security from './security.js';
+import tools from './tools.js';
+import docker from './docker.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/en/templates/global_sections/logging.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableFileNotFoundErrorLogging: `${common.enable} file not found error logging in`,

--- a/src/nginxconfig/i18n/en/templates/global_sections/nginx.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/nginx.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     nginxConfigDirectory: `${common.nginx} config directory`,

--- a/src/nginxconfig/i18n/en/templates/global_sections/performance.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/performance.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     disableHtmlCaching: 'Disable HTML caching',

--- a/src/nginxconfig/i18n/en/templates/global_sections/python.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonServer: `${common.python} server`,

--- a/src/nginxconfig/i18n/en/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const legacyXForwarded = 'Legacy X-Forwarded-* headers';
 

--- a/src/nginxconfig/i18n/en/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/security.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `When using ${common.wordPress}, <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code> is often required in the Content Security Policy to allow the admin panel to function correctly.`,

--- a/src/nginxconfig/i18n/en/templates/global_sections/tools.js
+++ b/src/nginxconfig/i18n/en/templates/global_sections/tools.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     modularizedStructure: 'Modularized structure',

--- a/src/nginxconfig/i18n/en/templates/index.js
+++ b/src/nginxconfig/i18n/en/templates/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,12 +24,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import app from './app';
-import setup from './setup';
-import footer from './footer';
-import domainSections from './domain_sections';
-import globalSections from './global_sections';
-import setupSections from './setup_sections';
-import callouts from './callouts';
+import app from './app.js';
+import setup from './setup.js';
+import footer from './footer.js';
+import domainSections from './domain_sections/index.js';
+import globalSections from './global_sections/index.js';
+import setupSections from './setup_sections/index.js';
+import callouts from './callouts/index.js';
 
 export default { app, setup, footer, domainSections, globalSections, setupSections, callouts };

--- a/src/nginxconfig/i18n/en/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/en/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const certbot = 'Certbot';
 

--- a/src/nginxconfig/i18n/en/templates/setup_sections/download.js
+++ b/src/nginxconfig/i18n/en/templates/setup_sections/download.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     downloadTheGeneratedConfig: '<b>Download</b> the generated config:',

--- a/src/nginxconfig/i18n/en/templates/setup_sections/go_live.js
+++ b/src/nginxconfig/i18n/en/templates/setup_sections/go_live.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     letsGoLive: "Let's go live!",

--- a/src/nginxconfig/i18n/en/templates/setup_sections/index.js
+++ b/src/nginxconfig/i18n/en/templates/setup_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import certbot from './certbot';
-import download from './download';
-import goLive from './go_live';
-import ssl from './ssl';
+import certbot from './certbot.js';
+import download from './download.js';
+import goLive from './go_live.js';
+import ssl from './ssl.js';
 
 export default { certbot, download, goLive, ssl };

--- a/src/nginxconfig/i18n/en/templates/setup_sections/ssl.js
+++ b/src/nginxconfig/i18n/en/templates/setup_sections/ssl.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     generateDiffieHellmanKeysByRunningThisCommandOnYourServer:

--- a/src/nginxconfig/i18n/es/index.js
+++ b/src/nginxconfig/i18n/es/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/es/index.js
+++ b/src/nginxconfig/i18n/es/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -26,6 +26,6 @@ THE SOFTWARE.
 
 import common from './common.js';
 import languages from './languages.js';
-import templates from './templates';
+import templates from './templates/index.js';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/es/templates/app.js
+++ b/src/nginxconfig/i18n/es/templates/app.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../common';
+import common from '../common.js';
 
 export default {
     title: `${common.nginx}Config`,

--- a/src/nginxconfig/i18n/es/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/es/templates/callouts/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import droplet from './droplet';
-import contribute from './contribute';
+import droplet from './droplet.js';
+import contribute from './contribute.js';
 
 export default { droplet, contribute };

--- a/src/nginxconfig/i18n/es/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/es/templates/domain_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableEncryptedSslConnection: `${common.enable} conexiones ${common.ssl} encriptadas`,

--- a/src/nginxconfig/i18n/es/templates/domain_sections/index.js
+++ b/src/nginxconfig/i18n/es/templates/domain_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,16 +24,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import php from './php';
-import presets from './presets';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import routing from './routing';
-import server from './server';
-import restrict from './restrict';
-import onion from './onion';
+import https from './https.js';
+import logging from './logging.js';
+import php from './php.js';
+import presets from './presets.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import routing from './routing.js';
+import server from './server.js';
+import restrict from './restrict.js';
+import onion from './onion.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/es/templates/domain_sections/logging.js
+++ b/src/nginxconfig/i18n/es/templates/domain_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     byDomain: 'por dominio',

--- a/src/nginxconfig/i18n/es/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/es/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     phpIsDisabled: `${common.php} esta desactivado.`,

--- a/src/nginxconfig/i18n/es/templates/domain_sections/python.js
+++ b/src/nginxconfig/i18n/es/templates/domain_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonIsDisabled: `${common.python} esta desactivado.`,

--- a/src/nginxconfig/i18n/es/templates/domain_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/es/templates/domain_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     reverseProxyIsDisabled: `${common.reverseProxy} esta desactivado.`,

--- a/src/nginxconfig/i18n/es/templates/domain_sections/routing.js
+++ b/src/nginxconfig/i18n/es/templates/domain_sections/routing.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     fallbackRouting: 'Enrutamiento alternativo',

--- a/src/nginxconfig/i18n/es/templates/global_sections/docker.js
+++ b/src/nginxconfig/i18n/es/templates/global_sections/docker.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const docker = 'Docker';
 const dockerfile = 'Dockerfile';

--- a/src/nginxconfig/i18n/es/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/es/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const mozilla = 'Mozilla';
 const ipv4 = 'IPv4';

--- a/src/nginxconfig/i18n/es/templates/global_sections/index.js
+++ b/src/nginxconfig/i18n/es/templates/global_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,15 +24,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import nginx from './nginx';
-import performance from './performance';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import security from './security';
-import tools from './tools';
-import docker from './docker';
+import https from './https.js';
+import logging from './logging.js';
+import nginx from './nginx.js';
+import performance from './performance.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import security from './security.js';
+import tools from './tools.js';
+import docker from './docker.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/es/templates/global_sections/logging.js
+++ b/src/nginxconfig/i18n/es/templates/global_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableFileNotFoundErrorLogging: `${common.enable} el registro de error de archivo no encontrado`,

--- a/src/nginxconfig/i18n/es/templates/global_sections/nginx.js
+++ b/src/nginxconfig/i18n/es/templates/global_sections/nginx.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     nginxConfigDirectory: `Directorio de configuración de ${common.nginx}`,

--- a/src/nginxconfig/i18n/es/templates/global_sections/performance.js
+++ b/src/nginxconfig/i18n/es/templates/global_sections/performance.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     disableHtmlCaching: 'Disable HTML caching', // TODO: translate

--- a/src/nginxconfig/i18n/es/templates/global_sections/python.js
+++ b/src/nginxconfig/i18n/es/templates/global_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonServer: `Servidor ${common.python}`,

--- a/src/nginxconfig/i18n/es/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/es/templates/global_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const legacyXForwarded = 'Cabeceras X-Forwarded-* Legacy';
 

--- a/src/nginxconfig/i18n/es/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/es/templates/global_sections/security.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `Cuando usan ${common.wordPress}, <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code> es usualmente requerido en el Content Security Policy para permitir que el panel de administrador funcione correctamente.`,

--- a/src/nginxconfig/i18n/es/templates/global_sections/tools.js
+++ b/src/nginxconfig/i18n/es/templates/global_sections/tools.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     modularizedStructure: 'Estructura modularizada',

--- a/src/nginxconfig/i18n/es/templates/index.js
+++ b/src/nginxconfig/i18n/es/templates/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,12 +24,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import app from './app';
-import setup from './setup';
-import footer from './footer';
-import domainSections from './domain_sections';
-import globalSections from './global_sections';
-import setupSections from './setup_sections';
-import callouts from './callouts';
+import app from './app.js';
+import setup from './setup.js';
+import footer from './footer.js';
+import domainSections from './domain_sections/index.js';
+import globalSections from './global_sections/index.js';
+import setupSections from './setup_sections/index.js';
+import callouts from './callouts/index.js';
 
 export default { app, setup, footer, domainSections, globalSections, setupSections, callouts };

--- a/src/nginxconfig/i18n/es/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/es/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const certbot = 'Certbot';
 

--- a/src/nginxconfig/i18n/es/templates/setup_sections/download.js
+++ b/src/nginxconfig/i18n/es/templates/setup_sections/download.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 // Here is a HACK, because the real traslation is: "y subirla en la carpeta '/etc/nginx' de tu servidor. "
 // but the HTML order of the templates are wrong: "y subirla en el servidor '/etc/nginx' carpeta."

--- a/src/nginxconfig/i18n/es/templates/setup_sections/go_live.js
+++ b/src/nginxconfig/i18n/es/templates/setup_sections/go_live.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     letsGoLive: '¡Vamos a desplegar!',

--- a/src/nginxconfig/i18n/es/templates/setup_sections/index.js
+++ b/src/nginxconfig/i18n/es/templates/setup_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import certbot from './certbot';
-import download from './download';
-import goLive from './go_live';
-import ssl from './ssl';
+import certbot from './certbot.js';
+import download from './download.js';
+import goLive from './go_live.js';
+import ssl from './ssl.js';
 
 export default { certbot, download, goLive, ssl };

--- a/src/nginxconfig/i18n/es/templates/setup_sections/ssl.js
+++ b/src/nginxconfig/i18n/es/templates/setup_sections/ssl.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     generateDiffieHellmanKeysByRunningThisCommandOnYourServer:

--- a/src/nginxconfig/i18n/fa/index.js
+++ b/src/nginxconfig/i18n/fa/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/fa/index.js
+++ b/src/nginxconfig/i18n/fa/index.js
@@ -26,6 +26,6 @@ THE SOFTWARE.
 
 import common from './common.js';
 import languages from './languages.js';
-import templates from './templates';
+import templates from './templates/index.js';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/fa/templates/app.js
+++ b/src/nginxconfig/i18n/fa/templates/app.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../common';
+import common from '../common.js';
 
 export default {
     title: `${common.nginx}پیکربندی`,

--- a/src/nginxconfig/i18n/fa/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/fa/templates/callouts/index.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import droplet from './droplet';
-import contribute from './contribute';
+import droplet from './droplet.js';
+import contribute from './contribute.js';
 
 export default { droplet, contribute };

--- a/src/nginxconfig/i18n/fa/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/fa/templates/domain_sections/https.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableEncryptedSslConnection: `${common.enable} ${common.ssl} اتصال‌های رمزگذاری شده`,

--- a/src/nginxconfig/i18n/fa/templates/domain_sections/index.js
+++ b/src/nginxconfig/i18n/fa/templates/domain_sections/index.js
@@ -24,16 +24,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import php from './php';
-import presets from './presets';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import routing from './routing';
-import server from './server';
-import restrict from './restrict';
-import onion from './onion';
+import https from './https.js';
+import logging from './logging.js';
+import php from './php.js';
+import presets from './presets.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import routing from './routing.js';
+import server from './server.js';
+import restrict from './restrict.js';
+import onion from './onion.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/fa/templates/domain_sections/logging.js
+++ b/src/nginxconfig/i18n/fa/templates/domain_sections/logging.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     byDomain: 'به وسیلهٔ دامنه',

--- a/src/nginxconfig/i18n/fa/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/fa/templates/domain_sections/php.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     phpIsDisabled: `${common.php} غیرفعال است.`,

--- a/src/nginxconfig/i18n/fa/templates/domain_sections/python.js
+++ b/src/nginxconfig/i18n/fa/templates/domain_sections/python.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonIsDisabled: `${common.python} غیرفعال است.`,

--- a/src/nginxconfig/i18n/fa/templates/domain_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/fa/templates/domain_sections/reverse_proxy.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     reverseProxyIsDisabled: `${common.reverseProxy} غیرفعال است.`,

--- a/src/nginxconfig/i18n/fa/templates/domain_sections/routing.js
+++ b/src/nginxconfig/i18n/fa/templates/domain_sections/routing.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     fallbackRouting: 'مسیریابی پشتیبانی شده',

--- a/src/nginxconfig/i18n/fa/templates/global_sections/docker.js
+++ b/src/nginxconfig/i18n/fa/templates/global_sections/docker.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const docker = 'Docker';
 const dockerfile = 'Dockerfile';

--- a/src/nginxconfig/i18n/fa/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/fa/templates/global_sections/https.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const mozilla = 'Mozilla';
 const ipv4 = 'IPv4';

--- a/src/nginxconfig/i18n/fa/templates/global_sections/index.js
+++ b/src/nginxconfig/i18n/fa/templates/global_sections/index.js
@@ -24,15 +24,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import nginx from './nginx';
-import performance from './performance';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import security from './security';
-import tools from './tools';
-import docker from './docker';
+import https from './https.js';
+import logging from './logging.js';
+import nginx from './nginx.js';
+import performance from './performance.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import security from './security.js';
+import tools from './tools.js';
+import docker from './docker.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/fa/templates/global_sections/logging.js
+++ b/src/nginxconfig/i18n/fa/templates/global_sections/logging.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableFileNotFoundErrorLogging: `${common.enable} ثبت خطاهای فایل پیدا نشد در ورودی`,

--- a/src/nginxconfig/i18n/fa/templates/global_sections/nginx.js
+++ b/src/nginxconfig/i18n/fa/templates/global_sections/nginx.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     nginxConfigDirectory: `${common.nginx} دایرکتوری پیکربندی`,

--- a/src/nginxconfig/i18n/fa/templates/global_sections/performance.js
+++ b/src/nginxconfig/i18n/fa/templates/global_sections/performance.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     disableHtmlCaching: 'غیرفعال کردن حافظه‌پنهان HTML',

--- a/src/nginxconfig/i18n/fa/templates/global_sections/python.js
+++ b/src/nginxconfig/i18n/fa/templates/global_sections/python.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonServer: `${common.python} سرور`,

--- a/src/nginxconfig/i18n/fa/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/fa/templates/global_sections/reverse_proxy.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const legacyXForwarded = 'Legacy X-Forwarded-* headers';
 

--- a/src/nginxconfig/i18n/fa/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/fa/templates/global_sections/security.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `هنگام استفاده از ${common.wordPress}، <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code> اغلب برای اجازه به پنل مدیریت برای عملکرد صحیح، در سیاست امنیتی محتوا مورد نیاز است.`,

--- a/src/nginxconfig/i18n/fa/templates/global_sections/tools.js
+++ b/src/nginxconfig/i18n/fa/templates/global_sections/tools.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     modularizedStructure: 'ساختار ماژولار',

--- a/src/nginxconfig/i18n/fa/templates/index.js
+++ b/src/nginxconfig/i18n/fa/templates/index.js
@@ -24,12 +24,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import app from './app';
-import setup from './setup';
-import footer from './footer';
-import domainSections from './domain_sections';
-import globalSections from './global_sections';
-import setupSections from './setup_sections';
-import callouts from './callouts';
+import app from './app.js';
+import setup from './setup.js';
+import footer from './footer.js';
+import domainSections from './domain_sections/index.js';
+import globalSections from './global_sections/index.js';
+import setupSections from './setup_sections/index.js';
+import callouts from './callouts/index.js';
 
 export default { app, setup, footer, domainSections, globalSections, setupSections, callouts };

--- a/src/nginxconfig/i18n/fa/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/fa/templates/setup_sections/certbot.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const certbot = 'Certbot';
 

--- a/src/nginxconfig/i18n/fa/templates/setup_sections/download.js
+++ b/src/nginxconfig/i18n/fa/templates/setup_sections/download.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     downloadTheGeneratedConfig: '<b>دانلود</b> پیکربندی تولید شده:',

--- a/src/nginxconfig/i18n/fa/templates/setup_sections/go_live.js
+++ b/src/nginxconfig/i18n/fa/templates/setup_sections/go_live.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     letsGoLive: 'بیایید زنده شویم!',

--- a/src/nginxconfig/i18n/fa/templates/setup_sections/index.js
+++ b/src/nginxconfig/i18n/fa/templates/setup_sections/index.js
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import certbot from './certbot';
-import download from './download';
-import goLive from './go_live';
-import ssl from './ssl';
+import certbot from './certbot.js';
+import download from './download.js';
+import goLive from './go_live.js';
+import ssl from './ssl.js';
 
 export default { certbot, download, goLive, ssl };

--- a/src/nginxconfig/i18n/fa/templates/setup_sections/ssl.js
+++ b/src/nginxconfig/i18n/fa/templates/setup_sections/ssl.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     generateDiffieHellmanKeysByRunningThisCommandOnYourServer:

--- a/src/nginxconfig/i18n/fr/index.js
+++ b/src/nginxconfig/i18n/fr/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/fr/index.js
+++ b/src/nginxconfig/i18n/fr/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -26,6 +26,6 @@ THE SOFTWARE.
 
 import common from './common.js';
 import languages from './languages.js';
-import templates from './templates';
+import templates from './templates/index.js';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/fr/templates/app.js
+++ b/src/nginxconfig/i18n/fr/templates/app.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../common';
+import common from '../common.js';
 
 export default {
     title: `${common.nginx}Config`,

--- a/src/nginxconfig/i18n/fr/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/fr/templates/callouts/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import droplet from './droplet';
-import contribute from './contribute';
+import droplet from './droplet.js';
+import contribute from './contribute.js';
 
 export default { droplet, contribute };

--- a/src/nginxconfig/i18n/fr/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/fr/templates/domain_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableEncryptedSslConnection: `${common.enable} les connexions ${common.ssl}`,

--- a/src/nginxconfig/i18n/fr/templates/domain_sections/index.js
+++ b/src/nginxconfig/i18n/fr/templates/domain_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,16 +24,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import php from './php';
-import presets from './presets';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import routing from './routing';
-import server from './server';
-import restrict from './restrict';
-import onion from './onion';
+import https from './https.js';
+import logging from './logging.js';
+import php from './php.js';
+import presets from './presets.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import routing from './routing.js';
+import server from './server.js';
+import restrict from './restrict.js';
+import onion from './onion.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/fr/templates/domain_sections/logging.js
+++ b/src/nginxconfig/i18n/fr/templates/domain_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     byDomain: 'par domaine',

--- a/src/nginxconfig/i18n/fr/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/fr/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     phpIsDisabled: `${common.php} est désactivé.`,

--- a/src/nginxconfig/i18n/fr/templates/domain_sections/python.js
+++ b/src/nginxconfig/i18n/fr/templates/domain_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonIsDisabled: `${common.python} est désactivé.`,

--- a/src/nginxconfig/i18n/fr/templates/domain_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/fr/templates/domain_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     reverseProxyIsDisabled: `Le ${common.reverseProxyLower} est désactivé.`,

--- a/src/nginxconfig/i18n/fr/templates/domain_sections/routing.js
+++ b/src/nginxconfig/i18n/fr/templates/domain_sections/routing.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     fallbackRouting: 'Routes par défaut',

--- a/src/nginxconfig/i18n/fr/templates/global_sections/docker.js
+++ b/src/nginxconfig/i18n/fr/templates/global_sections/docker.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const docker = 'Docker';
 const dockerfile = 'Dockerfile';

--- a/src/nginxconfig/i18n/fr/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/fr/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const mozilla = 'Mozilla';
 const ipv4 = 'IPv4';

--- a/src/nginxconfig/i18n/fr/templates/global_sections/index.js
+++ b/src/nginxconfig/i18n/fr/templates/global_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,15 +24,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import nginx from './nginx';
-import performance from './performance';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import security from './security';
-import tools from './tools';
-import docker from './docker';
+import https from './https.js';
+import logging from './logging.js';
+import nginx from './nginx.js';
+import performance from './performance.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import security from './security.js';
+import tools from './tools.js';
+import docker from './docker.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/fr/templates/global_sections/logging.js
+++ b/src/nginxconfig/i18n/fr/templates/global_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableFileNotFoundErrorLogging: `${common.enable} les erreurs de fichiers introuvables lors de la journalisation`,

--- a/src/nginxconfig/i18n/fr/templates/global_sections/nginx.js
+++ b/src/nginxconfig/i18n/fr/templates/global_sections/nginx.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     nginxConfigDirectory: `Dossier de configuration ${common.nginx}`,

--- a/src/nginxconfig/i18n/fr/templates/global_sections/performance.js
+++ b/src/nginxconfig/i18n/fr/templates/global_sections/performance.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     disableHtmlCaching: 'Disable HTML caching', // TODO: translate

--- a/src/nginxconfig/i18n/fr/templates/global_sections/python.js
+++ b/src/nginxconfig/i18n/fr/templates/global_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonServer: `Serveur ${common.python}`,

--- a/src/nginxconfig/i18n/fr/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/fr/templates/global_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const legacyXForwarded = 'En-têtes dépréciés X-Forwarded-*';
 

--- a/src/nginxconfig/i18n/fr/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/fr/templates/global_sections/security.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `Lors de l'utilisation de ${common.wordPress}, <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code> est fréquemment exigé par la Politique de Sécurité du Contenu pour assurer le bon fonctionnement du panneau d'administration.`,

--- a/src/nginxconfig/i18n/fr/templates/global_sections/tools.js
+++ b/src/nginxconfig/i18n/fr/templates/global_sections/tools.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     modularizedStructure: 'Structure modulaire',

--- a/src/nginxconfig/i18n/fr/templates/index.js
+++ b/src/nginxconfig/i18n/fr/templates/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,12 +24,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import app from './app';
-import setup from './setup';
-import footer from './footer';
-import domainSections from './domain_sections';
-import globalSections from './global_sections';
-import setupSections from './setup_sections';
-import callouts from './callouts';
+import app from './app.js';
+import setup from './setup.js';
+import footer from './footer.js';
+import domainSections from './domain_sections/index.js';
+import globalSections from './global_sections/index.js';
+import setupSections from './setup_sections/index.js';
+import callouts from './callouts/index.js';
 
 export default { app, setup, footer, domainSections, globalSections, setupSections, callouts };

--- a/src/nginxconfig/i18n/fr/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/fr/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const certbot = 'Certbot';
 

--- a/src/nginxconfig/i18n/fr/templates/setup_sections/download.js
+++ b/src/nginxconfig/i18n/fr/templates/setup_sections/download.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     downloadTheGeneratedConfig: '<b>Téléchargez</b> la configuration générée:',

--- a/src/nginxconfig/i18n/fr/templates/setup_sections/go_live.js
+++ b/src/nginxconfig/i18n/fr/templates/setup_sections/go_live.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     letsGoLive: "C'est en ligne!",

--- a/src/nginxconfig/i18n/fr/templates/setup_sections/index.js
+++ b/src/nginxconfig/i18n/fr/templates/setup_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import certbot from './certbot';
-import download from './download';
-import goLive from './go_live';
-import ssl from './ssl';
+import certbot from './certbot.js';
+import download from './download.js';
+import goLive from './go_live.js';
+import ssl from './ssl.js';
 
 export default { certbot, download, goLive, ssl };

--- a/src/nginxconfig/i18n/fr/templates/setup_sections/ssl.js
+++ b/src/nginxconfig/i18n/fr/templates/setup_sections/ssl.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     generateDiffieHellmanKeysByRunningThisCommandOnYourServer:

--- a/src/nginxconfig/i18n/ja/index.js
+++ b/src/nginxconfig/i18n/ja/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/ja/index.js
+++ b/src/nginxconfig/i18n/ja/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -26,6 +26,6 @@ THE SOFTWARE.
 
 import common from './common.js';
 import languages from './languages.js';
-import templates from './templates';
+import templates from './templates/index.js';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/ja/templates/app.js
+++ b/src/nginxconfig/i18n/ja/templates/app.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../common';
+import common from '../common.js';
 
 export default {
     title: `${common.nginx}設定`,

--- a/src/nginxconfig/i18n/ja/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/ja/templates/callouts/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import droplet from './droplet';
-import contribute from './contribute';
+import droplet from './droplet.js';
+import contribute from './contribute.js';
 
 export default { droplet, contribute };

--- a/src/nginxconfig/i18n/ja/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/ja/templates/domain_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableEncryptedSslConnection: `暗号化された ${common.ssl} 接続を${common.enable}`,

--- a/src/nginxconfig/i18n/ja/templates/domain_sections/index.js
+++ b/src/nginxconfig/i18n/ja/templates/domain_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,16 +24,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import php from './php';
-import presets from './presets';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import routing from './routing';
-import server from './server';
-import restrict from './restrict';
-import onion from './onion';
+import https from './https.js';
+import logging from './logging.js';
+import php from './php.js';
+import presets from './presets.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import routing from './routing.js';
+import server from './server.js';
+import restrict from './restrict.js';
+import onion from './onion.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/ja/templates/domain_sections/logging.js
+++ b/src/nginxconfig/i18n/ja/templates/domain_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     byDomain: '(ドメインごと)',

--- a/src/nginxconfig/i18n/ja/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/ja/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     phpIsDisabled: `${common.php} は無効です。`,

--- a/src/nginxconfig/i18n/ja/templates/domain_sections/python.js
+++ b/src/nginxconfig/i18n/ja/templates/domain_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonIsDisabled: `${common.python} は無効です。`,

--- a/src/nginxconfig/i18n/ja/templates/domain_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/ja/templates/domain_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     reverseProxyIsDisabled: `${common.reverseProxy} は無効です。`,

--- a/src/nginxconfig/i18n/ja/templates/domain_sections/routing.js
+++ b/src/nginxconfig/i18n/ja/templates/domain_sections/routing.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     fallbackRouting: 'フォールバックルーティング',

--- a/src/nginxconfig/i18n/ja/templates/global_sections/docker.js
+++ b/src/nginxconfig/i18n/ja/templates/global_sections/docker.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const docker = 'Docker';
 const dockerfile = 'Dockerfile';

--- a/src/nginxconfig/i18n/ja/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/ja/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const mozilla = 'Mozilla';
 const ipv4 = 'IPv4';

--- a/src/nginxconfig/i18n/ja/templates/global_sections/index.js
+++ b/src/nginxconfig/i18n/ja/templates/global_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,15 +24,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import nginx from './nginx';
-import performance from './performance';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import security from './security';
-import tools from './tools';
-import docker from './docker';
+import https from './https.js';
+import logging from './logging.js';
+import nginx from './nginx.js';
+import performance from './performance.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import security from './security.js';
+import tools from './tools.js';
+import docker from './docker.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/ja/templates/global_sections/logging.js
+++ b/src/nginxconfig/i18n/ja/templates/global_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableFileNotFoundErrorLogging: `FILE NOT FOUND エラーのロギングを${common.enable}`,

--- a/src/nginxconfig/i18n/ja/templates/global_sections/nginx.js
+++ b/src/nginxconfig/i18n/ja/templates/global_sections/nginx.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     nginxConfigDirectory: `${common.nginx} 設定ディレクトリ`,

--- a/src/nginxconfig/i18n/ja/templates/global_sections/performance.js
+++ b/src/nginxconfig/i18n/ja/templates/global_sections/performance.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     disableHtmlCaching: 'HTML キャッシュの無効化',

--- a/src/nginxconfig/i18n/ja/templates/global_sections/python.js
+++ b/src/nginxconfig/i18n/ja/templates/global_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonServer: `${common.python} サーバ`,

--- a/src/nginxconfig/i18n/ja/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/ja/templates/global_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const legacyXForwarded = 'Legacy X-Forwarded-* headers';
 

--- a/src/nginxconfig/i18n/ja/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/ja/templates/global_sections/security.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `${common.wordPress} を利用している場合、 <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code> は、管理画面を正しく機能させるために、コンテンツセキュリティポリシーで要求されることが多いようです。`,

--- a/src/nginxconfig/i18n/ja/templates/global_sections/tools.js
+++ b/src/nginxconfig/i18n/ja/templates/global_sections/tools.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     modularizedStructure: 'モジュール化された構造',

--- a/src/nginxconfig/i18n/ja/templates/index.js
+++ b/src/nginxconfig/i18n/ja/templates/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,12 +24,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import app from './app';
-import setup from './setup';
-import footer from './footer';
-import domainSections from './domain_sections';
-import globalSections from './global_sections';
-import setupSections from './setup_sections';
-import callouts from './callouts';
+import app from './app.js';
+import setup from './setup.js';
+import footer from './footer.js';
+import domainSections from './domain_sections/index.js';
+import globalSections from './global_sections/index.js';
+import setupSections from './setup_sections/index.js';
+import callouts from './callouts/index.js';
 
 export default { app, setup, footer, domainSections, globalSections, setupSections, callouts };

--- a/src/nginxconfig/i18n/ja/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/ja/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const certbot = 'Certbot';
 

--- a/src/nginxconfig/i18n/ja/templates/setup_sections/download.js
+++ b/src/nginxconfig/i18n/ja/templates/setup_sections/download.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     downloadTheGeneratedConfig: '生成された設定ファイルを<b>ダウンロードします</b>:',

--- a/src/nginxconfig/i18n/ja/templates/setup_sections/go_live.js
+++ b/src/nginxconfig/i18n/ja/templates/setup_sections/go_live.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     letsGoLive: '起動しよう!',

--- a/src/nginxconfig/i18n/ja/templates/setup_sections/index.js
+++ b/src/nginxconfig/i18n/ja/templates/setup_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import certbot from './certbot';
-import download from './download';
-import goLive from './go_live';
-import ssl from './ssl';
+import certbot from './certbot.js';
+import download from './download.js';
+import goLive from './go_live.js';
+import ssl from './ssl.js';
 
 export default { certbot, download, goLive, ssl };

--- a/src/nginxconfig/i18n/ja/templates/setup_sections/ssl.js
+++ b/src/nginxconfig/i18n/ja/templates/setup_sections/ssl.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     generateDiffieHellmanKeysByRunningThisCommandOnYourServer:

--- a/src/nginxconfig/i18n/pl/index.js
+++ b/src/nginxconfig/i18n/pl/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/pl/index.js
+++ b/src/nginxconfig/i18n/pl/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -26,6 +26,6 @@ THE SOFTWARE.
 
 import common from './common.js';
 import languages from './languages.js';
-import templates from './templates';
+import templates from './templates/index.js';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/pl/templates/app.js
+++ b/src/nginxconfig/i18n/pl/templates/app.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../common';
+import common from '../common.js';
 
 export default {
     title: `${common.nginx}Config`,

--- a/src/nginxconfig/i18n/pl/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/pl/templates/callouts/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import droplet from './droplet';
-import contribute from './contribute';
+import droplet from './droplet.js';
+import contribute from './contribute.js';
 
 export default { droplet, contribute };

--- a/src/nginxconfig/i18n/pl/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/pl/templates/domain_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableEncryptedSslConnection: `${common.enable} szyfrowane połączenie ${common.ssl}`,

--- a/src/nginxconfig/i18n/pl/templates/domain_sections/index.js
+++ b/src/nginxconfig/i18n/pl/templates/domain_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,16 +24,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import php from './php';
-import presets from './presets';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import routing from './routing';
-import server from './server';
-import restrict from './restrict';
-import onion from './onion';
+import https from './https.js';
+import logging from './logging.js';
+import php from './php.js';
+import presets from './presets.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import routing from './routing.js';
+import server from './server.js';
+import restrict from './restrict.js';
+import onion from './onion.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/pl/templates/domain_sections/logging.js
+++ b/src/nginxconfig/i18n/pl/templates/domain_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     byDomain: 'wg. domen',

--- a/src/nginxconfig/i18n/pl/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/pl/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     phpIsDisabled: `${common.php} jest wyłączony.`,

--- a/src/nginxconfig/i18n/pl/templates/domain_sections/python.js
+++ b/src/nginxconfig/i18n/pl/templates/domain_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonIsDisabled: `${common.python} jest wyłączony.`,

--- a/src/nginxconfig/i18n/pl/templates/domain_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/pl/templates/domain_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     reverseProxyIsDisabled: `${common.reverseProxy} jest wyłączone.`,

--- a/src/nginxconfig/i18n/pl/templates/domain_sections/routing.js
+++ b/src/nginxconfig/i18n/pl/templates/domain_sections/routing.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     fallbackRouting: 'Routing rezerwowy',

--- a/src/nginxconfig/i18n/pl/templates/global_sections/docker.js
+++ b/src/nginxconfig/i18n/pl/templates/global_sections/docker.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const docker = 'Docker';
 const dockerfile = 'Dockerfile';

--- a/src/nginxconfig/i18n/pl/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/pl/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const mozilla = 'Mozilla';
 const ipv4 = 'IPv4';

--- a/src/nginxconfig/i18n/pl/templates/global_sections/index.js
+++ b/src/nginxconfig/i18n/pl/templates/global_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,15 +24,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import nginx from './nginx';
-import performance from './performance';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import security from './security';
-import tools from './tools';
-import docker from './docker';
+import https from './https.js';
+import logging from './logging.js';
+import nginx from './nginx.js';
+import performance from './performance.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import security from './security.js';
+import tools from './tools.js';
+import docker from './docker.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/pl/templates/global_sections/logging.js
+++ b/src/nginxconfig/i18n/pl/templates/global_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableFileNotFoundErrorLogging: `${common.enable} logowanie błędów o nieznalezionych plikach`,

--- a/src/nginxconfig/i18n/pl/templates/global_sections/nginx.js
+++ b/src/nginxconfig/i18n/pl/templates/global_sections/nginx.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     nginxConfigDirectory: `ścieżka konfiguracji ${common.nginx}`,

--- a/src/nginxconfig/i18n/pl/templates/global_sections/performance.js
+++ b/src/nginxconfig/i18n/pl/templates/global_sections/performance.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     disableHtmlCaching: 'Disable HTML caching', // TODO: translate

--- a/src/nginxconfig/i18n/pl/templates/global_sections/python.js
+++ b/src/nginxconfig/i18n/pl/templates/global_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonServer: `Serwer ${common.python}`,

--- a/src/nginxconfig/i18n/pl/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/pl/templates/global_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const legacyXForwarded = 'nagłówka X-Forwarded-* starego typu';
 

--- a/src/nginxconfig/i18n/pl/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/pl/templates/global_sections/security.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `Korzystając z ${common.wordPress}, <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code> jest często wymagany w Content Security Policy aby panel administracyjny działał poprawnie.`,

--- a/src/nginxconfig/i18n/pl/templates/global_sections/tools.js
+++ b/src/nginxconfig/i18n/pl/templates/global_sections/tools.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     modularizedStructure: 'Struktura modułowa',

--- a/src/nginxconfig/i18n/pl/templates/index.js
+++ b/src/nginxconfig/i18n/pl/templates/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,12 +24,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import app from './app';
-import setup from './setup';
-import footer from './footer';
-import domainSections from './domain_sections';
-import globalSections from './global_sections';
-import setupSections from './setup_sections';
-import callouts from './callouts';
+import app from './app.js';
+import setup from './setup.js';
+import footer from './footer.js';
+import domainSections from './domain_sections/index.js';
+import globalSections from './global_sections/index.js';
+import setupSections from './setup_sections/index.js';
+import callouts from './callouts/index.js';
 
 export default { app, setup, footer, domainSections, globalSections, setupSections, callouts };

--- a/src/nginxconfig/i18n/pl/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/pl/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const certbot = 'Certbot';
 

--- a/src/nginxconfig/i18n/pl/templates/setup_sections/download.js
+++ b/src/nginxconfig/i18n/pl/templates/setup_sections/download.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     downloadTheGeneratedConfig: '<b>Pobierz</b> wygenerowany konfig:',

--- a/src/nginxconfig/i18n/pl/templates/setup_sections/go_live.js
+++ b/src/nginxconfig/i18n/pl/templates/setup_sections/go_live.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     letsGoLive: 'Do dzieła!',

--- a/src/nginxconfig/i18n/pl/templates/setup_sections/index.js
+++ b/src/nginxconfig/i18n/pl/templates/setup_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import certbot from './certbot';
-import download from './download';
-import goLive from './go_live';
-import ssl from './ssl';
+import certbot from './certbot.js';
+import download from './download.js';
+import goLive from './go_live.js';
+import ssl from './ssl.js';
 
 export default { certbot, download, goLive, ssl };

--- a/src/nginxconfig/i18n/pl/templates/setup_sections/ssl.js
+++ b/src/nginxconfig/i18n/pl/templates/setup_sections/ssl.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     generateDiffieHellmanKeysByRunningThisCommandOnYourServer:

--- a/src/nginxconfig/i18n/pt-br/index.js
+++ b/src/nginxconfig/i18n/pt-br/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -26,6 +26,6 @@ THE SOFTWARE.
 
 import common from './common.js';
 import languages from './languages.js';
-import templates from './templates';
+import templates from './templates/index.js';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/pt-br/index.js
+++ b/src/nginxconfig/i18n/pt-br/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/pt-br/templates/app.js
+++ b/src/nginxconfig/i18n/pt-br/templates/app.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../common';
+import common from '../common.js';
 
 export default {
     title: `${common.nginx}Configuração`,

--- a/src/nginxconfig/i18n/pt-br/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/pt-br/templates/callouts/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import droplet from './droplet';
-import contribute from './contribute';
+import droplet from './droplet.js';
+import contribute from './contribute.js';
 
 export default { droplet, contribute };

--- a/src/nginxconfig/i18n/pt-br/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/pt-br/templates/domain_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableEncryptedSslConnection: `${common.enable} conexões ${common.ssl} criptografadas`,

--- a/src/nginxconfig/i18n/pt-br/templates/domain_sections/index.js
+++ b/src/nginxconfig/i18n/pt-br/templates/domain_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,16 +24,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import php from './php';
-import presets from './presets';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import routing from './routing';
-import server from './server';
-import restrict from './restrict';
-import onion from './onion';
+import https from './https.js';
+import logging from './logging.js';
+import php from './php.js';
+import presets from './presets.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import routing from './routing.js';
+import server from './server.js';
+import restrict from './restrict.js';
+import onion from './onion.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/pt-br/templates/domain_sections/logging.js
+++ b/src/nginxconfig/i18n/pt-br/templates/domain_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     byDomain: 'por domínio',

--- a/src/nginxconfig/i18n/pt-br/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/pt-br/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     phpIsDisabled: `O ${common.php} está desabilitado.`,

--- a/src/nginxconfig/i18n/pt-br/templates/domain_sections/python.js
+++ b/src/nginxconfig/i18n/pt-br/templates/domain_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonIsDisabled: `O ${common.python} está desabilitado.`,

--- a/src/nginxconfig/i18n/pt-br/templates/domain_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/pt-br/templates/domain_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     reverseProxyIsDisabled: `O ${common.reverseProxy} está desabilitado.`,

--- a/src/nginxconfig/i18n/pt-br/templates/domain_sections/routing.js
+++ b/src/nginxconfig/i18n/pt-br/templates/domain_sections/routing.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     fallbackRouting: 'Roteamento alternativo',

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/docker.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/docker.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const docker = 'Docker';
 const dockerfile = 'Dockerfile';

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const mozilla = 'Mozilla';
 const ipv4 = 'IPv4';

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/index.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,15 +24,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import nginx from './nginx';
-import performance from './performance';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import security from './security';
-import tools from './tools';
-import docker from './docker';
+import https from './https.js';
+import logging from './logging.js';
+import nginx from './nginx.js';
+import performance from './performance.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import security from './security.js';
+import tools from './tools.js';
+import docker from './docker.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/logging.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableFileNotFoundErrorLogging: `${common.enable} erro de arquivo não encontrado ao fazer login`,

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/nginx.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/nginx.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     nginxConfigDirectory: `Diretório de configuração do ${common.nginx}`,

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/performance.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/performance.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     disableHtmlCaching: 'Disable HTML caching', // TODO: translate

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/python.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonServer: `Servidor ${common.python}`,

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const legacyXForwarded = 'Legacy X-Forwarded-* headers'; // TODO: translate
 

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/security.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `Ao utilizar o ${common.wordPress}, <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code> é frequentemente exigido na Política de Segurança de Conteúdo para permitir que o painel de administração funcione corretamente.`,

--- a/src/nginxconfig/i18n/pt-br/templates/global_sections/tools.js
+++ b/src/nginxconfig/i18n/pt-br/templates/global_sections/tools.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     modularizedStructure: 'Estrutura modularizada',

--- a/src/nginxconfig/i18n/pt-br/templates/index.js
+++ b/src/nginxconfig/i18n/pt-br/templates/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,12 +24,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import app from './app';
-import setup from './setup';
-import footer from './footer';
-import domainSections from './domain_sections';
-import globalSections from './global_sections';
-import setupSections from './setup_sections';
-import callouts from './callouts';
+import app from './app.js';
+import setup from './setup.js';
+import footer from './footer.js';
+import domainSections from './domain_sections/index.js';
+import globalSections from './global_sections/index.js';
+import setupSections from './setup_sections/index.js';
+import callouts from './callouts/index.js';
 
 export default { app, setup, footer, domainSections, globalSections, setupSections, callouts };

--- a/src/nginxconfig/i18n/pt-br/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/pt-br/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const certbot = 'Certbot';
 

--- a/src/nginxconfig/i18n/pt-br/templates/setup_sections/download.js
+++ b/src/nginxconfig/i18n/pt-br/templates/setup_sections/download.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     downloadTheGeneratedConfig: '<b>Baixe</b> a configuração gerada:',

--- a/src/nginxconfig/i18n/pt-br/templates/setup_sections/go_live.js
+++ b/src/nginxconfig/i18n/pt-br/templates/setup_sections/go_live.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     letsGoLive: 'Vamos colocar no ar!',

--- a/src/nginxconfig/i18n/pt-br/templates/setup_sections/index.js
+++ b/src/nginxconfig/i18n/pt-br/templates/setup_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import certbot from './certbot';
-import download from './download';
-import goLive from './go_live';
-import ssl from './ssl';
+import certbot from './certbot.js';
+import download from './download.js';
+import goLive from './go_live.js';
+import ssl from './ssl.js';
 
 export default { certbot, download, goLive, ssl };

--- a/src/nginxconfig/i18n/pt-br/templates/setup_sections/ssl.js
+++ b/src/nginxconfig/i18n/pt-br/templates/setup_sections/ssl.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     generateDiffieHellmanKeysByRunningThisCommandOnYourServer:

--- a/src/nginxconfig/i18n/ru/index.js
+++ b/src/nginxconfig/i18n/ru/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/ru/index.js
+++ b/src/nginxconfig/i18n/ru/index.js
@@ -26,6 +26,6 @@ THE SOFTWARE.
 
 import common from './common.js';
 import languages from './languages.js';
-import templates from './templates';
+import templates from './templates/index.js';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/ru/index.js
+++ b/src/nginxconfig/i18n/ru/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/ru/templates/app.js
+++ b/src/nginxconfig/i18n/ru/templates/app.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../common';
+import common from '../common.js';
 
 export default {
     title: `${common.nginx}Config`,

--- a/src/nginxconfig/i18n/ru/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/ru/templates/callouts/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import droplet from './droplet';
-import contribute from './contribute';
+import droplet from './droplet.js';
+import contribute from './contribute.js';
 
 export default { droplet, contribute };

--- a/src/nginxconfig/i18n/ru/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/ru/templates/domain_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableEncryptedSslConnection: `${common.enable} зашифрованные ${common.ssl} соединения`,

--- a/src/nginxconfig/i18n/ru/templates/domain_sections/index.js
+++ b/src/nginxconfig/i18n/ru/templates/domain_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,16 +24,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import php from './php';
-import presets from './presets';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import routing from './routing';
-import server from './server';
-import restrict from './restrict';
-import onion from './onion';
+import https from './https.js';
+import logging from './logging.js';
+import php from './php.js';
+import presets from './presets.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import routing from './routing.js';
+import server from './server.js';
+import restrict from './restrict.js';
+import onion from './onion.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/ru/templates/domain_sections/logging.js
+++ b/src/nginxconfig/i18n/ru/templates/domain_sections/logging.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     byDomain: 'по домену',

--- a/src/nginxconfig/i18n/ru/templates/domain_sections/logging.js
+++ b/src/nginxconfig/i18n/ru/templates/domain_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/ru/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/ru/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     phpIsDisabled: `${common.php} выключен.`,

--- a/src/nginxconfig/i18n/ru/templates/domain_sections/python.js
+++ b/src/nginxconfig/i18n/ru/templates/domain_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonIsDisabled: `${common.python} выключен.`,

--- a/src/nginxconfig/i18n/ru/templates/domain_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/ru/templates/domain_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     reverseProxyIsDisabled: `${common.reverseProxy} выключено.`,

--- a/src/nginxconfig/i18n/ru/templates/domain_sections/routing.js
+++ b/src/nginxconfig/i18n/ru/templates/domain_sections/routing.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     fallbackRouting: 'Fallback маршрутизация',

--- a/src/nginxconfig/i18n/ru/templates/global_sections/docker.js
+++ b/src/nginxconfig/i18n/ru/templates/global_sections/docker.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const docker = 'Docker';
 const dockerfile = 'Dockerfile';

--- a/src/nginxconfig/i18n/ru/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/ru/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const mozilla = 'Mozilla';
 const ipv4 = 'IPv4';

--- a/src/nginxconfig/i18n/ru/templates/global_sections/index.js
+++ b/src/nginxconfig/i18n/ru/templates/global_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,15 +24,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import nginx from './nginx';
-import performance from './performance';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import security from './security';
-import tools from './tools';
-import docker from './docker';
+import https from './https.js';
+import logging from './logging.js';
+import nginx from './nginx.js';
+import performance from './performance.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import security from './security.js';
+import tools from './tools.js';
+import docker from './docker.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/ru/templates/global_sections/logging.js
+++ b/src/nginxconfig/i18n/ru/templates/global_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableFileNotFoundErrorLogging: `${common.enable} логирование ошибок для файлов, которые не были найдены при запросе`,

--- a/src/nginxconfig/i18n/ru/templates/global_sections/nginx.js
+++ b/src/nginxconfig/i18n/ru/templates/global_sections/nginx.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     nginxConfigDirectory: `Директория конфигурации ${common.nginx}`,

--- a/src/nginxconfig/i18n/ru/templates/global_sections/performance.js
+++ b/src/nginxconfig/i18n/ru/templates/global_sections/performance.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     disableHtmlCaching: 'Disable HTML caching', // TODO: translate

--- a/src/nginxconfig/i18n/ru/templates/global_sections/python.js
+++ b/src/nginxconfig/i18n/ru/templates/global_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonServer: `${common.python} сервер`,

--- a/src/nginxconfig/i18n/ru/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/ru/templates/global_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const legacyXForwarded = 'Legacy X-Forwarded-* headers'; // TODO: translate
 

--- a/src/nginxconfig/i18n/ru/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/ru/templates/global_sections/security.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `Во время использования ${common.wordPress}, <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code> часто требуется в Content Security Policy, чтобы панель администратора работала исправно.`,

--- a/src/nginxconfig/i18n/ru/templates/global_sections/tools.js
+++ b/src/nginxconfig/i18n/ru/templates/global_sections/tools.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     modularizedStructure: 'Модульная структура',

--- a/src/nginxconfig/i18n/ru/templates/index.js
+++ b/src/nginxconfig/i18n/ru/templates/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,12 +24,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import app from './app';
-import setup from './setup';
-import footer from './footer';
-import domainSections from './domain_sections';
-import globalSections from './global_sections';
-import setupSections from './setup_sections';
-import callouts from './callouts';
+import app from './app.js';
+import setup from './setup.js';
+import footer from './footer.js';
+import domainSections from './domain_sections/index.js';
+import globalSections from './global_sections/index.js';
+import setupSections from './setup_sections/index.js';
+import callouts from './callouts/index.js';
 
 export default { app, setup, footer, domainSections, globalSections, setupSections, callouts };

--- a/src/nginxconfig/i18n/ru/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/ru/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const certbot = 'Certbot';
 

--- a/src/nginxconfig/i18n/ru/templates/setup_sections/download.js
+++ b/src/nginxconfig/i18n/ru/templates/setup_sections/download.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     downloadTheGeneratedConfig: '<b>Скачать</b> сгенерированную конфигурацию:',

--- a/src/nginxconfig/i18n/ru/templates/setup_sections/go_live.js
+++ b/src/nginxconfig/i18n/ru/templates/setup_sections/go_live.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     letsGoLive: 'Время запуска!',

--- a/src/nginxconfig/i18n/ru/templates/setup_sections/index.js
+++ b/src/nginxconfig/i18n/ru/templates/setup_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import certbot from './certbot';
-import download from './download';
-import goLive from './go_live';
-import ssl from './ssl';
+import certbot from './certbot.js';
+import download from './download.js';
+import goLive from './go_live.js';
+import ssl from './ssl.js';
 
 export default { certbot, download, goLive, ssl };

--- a/src/nginxconfig/i18n/ru/templates/setup_sections/ssl.js
+++ b/src/nginxconfig/i18n/ru/templates/setup_sections/ssl.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     generateDiffieHellmanKeysByRunningThisCommandOnYourServer:

--- a/src/nginxconfig/i18n/setup.js
+++ b/src/nginxconfig/i18n/setup.js
@@ -25,7 +25,7 @@ THE SOFTWARE.
 */
 
 import { createI18n } from 'vue-i18n';
-import { defaultPack, defaultPackData, toSep, availablePacks } from '../util/language_packs';
+import { defaultPack, defaultPackData, toSep, availablePacks } from '../util/language_packs.js';
 
 // Load in the full default pack
 const i18nPacks = {};

--- a/src/nginxconfig/i18n/setup.js
+++ b/src/nginxconfig/i18n/setup.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/verify.js
+++ b/src/nginxconfig/i18n/verify.js
@@ -28,8 +28,8 @@ import { readdirSync, readFileSync } from 'fs';
 import { join, sep } from 'path';
 import { URL } from 'url';
 import chalk from 'chalk';
-import { defaultPack, availablePacks, toSep, fromSep } from '../util/language_packs';
-import snakeToCamel from '../util/snake_to_camel';
+import { defaultPack, availablePacks, toSep, fromSep } from '../util/language_packs.js';
+import snakeToCamel from '../util/snake_to_camel.js';
 
 // Recursively get all keys in a i18n pack object fragment
 const explore = (packFragment) => {

--- a/src/nginxconfig/i18n/verify.js
+++ b/src/nginxconfig/i18n/verify.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/i18n/zh-cn/index.js
+++ b/src/nginxconfig/i18n/zh-cn/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -26,6 +26,6 @@ THE SOFTWARE.
 
 import common from './common.js';
 import languages from './languages.js';
-import templates from './templates';
+import templates from './templates/index.js';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/zh-cn/index.js
+++ b/src/nginxconfig/i18n/zh-cn/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/zh-cn/templates/app.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/app.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../common';
+import common from '../common.js';
 
 export default {
     title: `${common.nginx} 配置`,

--- a/src/nginxconfig/i18n/zh-cn/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/callouts/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import droplet from './droplet';
-import contribute from './contribute';
+import droplet from './droplet.js';
+import contribute from './contribute.js';
 
 export default { droplet, contribute };

--- a/src/nginxconfig/i18n/zh-cn/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/domain_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableEncryptedSslConnection: `${common.enable}加密的${common.ssl}连接`,

--- a/src/nginxconfig/i18n/zh-cn/templates/domain_sections/index.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/domain_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,16 +24,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import php from './php';
-import presets from './presets';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import routing from './routing';
-import server from './server';
-import restrict from './restrict';
-import onion from './onion';
+import https from './https.js';
+import logging from './logging.js';
+import php from './php.js';
+import presets from './presets.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import routing from './routing.js';
+import server from './server.js';
+import restrict from './restrict.js';
+import onion from './onion.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/zh-cn/templates/domain_sections/logging.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/domain_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     byDomain: '在此站点',

--- a/src/nginxconfig/i18n/zh-cn/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     phpIsDisabled: `${common.php}已禁用。`,

--- a/src/nginxconfig/i18n/zh-cn/templates/domain_sections/python.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/domain_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonIsDisabled: `${common.python}已禁用。`,

--- a/src/nginxconfig/i18n/zh-cn/templates/domain_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/domain_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     reverseProxyIsDisabled: `${common.reverseProxy}已禁用。`,

--- a/src/nginxconfig/i18n/zh-cn/templates/domain_sections/routing.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/domain_sections/routing.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     fallbackRouting: '后备路由',

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/docker.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/docker.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const docker = 'Docker';
 const dockerfile = 'Dockerfile';

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const mozilla = 'Mozilla';
 const ipv4 = 'IPv4';

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/index.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,15 +24,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import nginx from './nginx';
-import performance from './performance';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import security from './security';
-import tools from './tools';
-import docker from './docker';
+import https from './https.js';
+import logging from './logging.js';
+import nginx from './nginx.js';
+import performance from './performance.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import security from './security.js';
+import tools from './tools.js';
+import docker from './docker.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/logging.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableFileNotFoundErrorLogging: `${common.enable}“文件未找到”错误日志：`,

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/nginx.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/nginx.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     nginxConfigDirectory: `${common.nginx}配置目录`,

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/performance.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/performance.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     disableHtmlCaching: '禁用 HTML 缓存',

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/python.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonServer: `${common.python} 服务`,

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const legacyXForwarded = '传统 X-Forwarded-* 请求头';
 

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/security.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `当使用${common.wordPress}时，<code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code> 通常需要置于内容安全策略中，以确保管理面板的正常运行。`,

--- a/src/nginxconfig/i18n/zh-cn/templates/global_sections/tools.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/global_sections/tools.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     modularizedStructure: '模块化结构',

--- a/src/nginxconfig/i18n/zh-cn/templates/index.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,12 +24,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import app from './app';
-import setup from './setup';
-import footer from './footer';
-import domainSections from './domain_sections';
-import globalSections from './global_sections';
-import setupSections from './setup_sections';
-import callouts from './callouts';
+import app from './app.js';
+import setup from './setup.js';
+import footer from './footer.js';
+import domainSections from './domain_sections/index.js';
+import globalSections from './global_sections/index.js';
+import setupSections from './setup_sections/index.js';
+import callouts from './callouts/index.js';
 
 export default { app, setup, footer, domainSections, globalSections, setupSections, callouts };

--- a/src/nginxconfig/i18n/zh-cn/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const certbot = 'Certbot';
 

--- a/src/nginxconfig/i18n/zh-cn/templates/setup_sections/download.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/setup_sections/download.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     downloadTheGeneratedConfig: '<b>下载</b> 生成的配置:',

--- a/src/nginxconfig/i18n/zh-cn/templates/setup_sections/go_live.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/setup_sections/go_live.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     letsGoLive: '让我们开始吧！',

--- a/src/nginxconfig/i18n/zh-cn/templates/setup_sections/index.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/setup_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import certbot from './certbot';
-import download from './download';
-import goLive from './go_live';
-import ssl from './ssl';
+import certbot from './certbot.js';
+import download from './download.js';
+import goLive from './go_live.js';
+import ssl from './ssl.js';
 
 export default { certbot, download, goLive, ssl };

--- a/src/nginxconfig/i18n/zh-cn/templates/setup_sections/ssl.js
+++ b/src/nginxconfig/i18n/zh-cn/templates/setup_sections/ssl.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     generateDiffieHellmanKeysByRunningThisCommandOnYourServer:

--- a/src/nginxconfig/i18n/zh-tw/index.js
+++ b/src/nginxconfig/i18n/zh-tw/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -26,6 +26,6 @@ THE SOFTWARE.
 
 import common from './common.js';
 import languages from './languages.js';
-import templates from './templates';
+import templates from './templates/index.js';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/zh-tw/index.js
+++ b/src/nginxconfig/i18n/zh-tw/index.js
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from './common';
-import languages from './languages';
+import common from './common.js';
+import languages from './languages.js';
 import templates from './templates';
 
 export default { common, languages, templates };

--- a/src/nginxconfig/i18n/zh-tw/templates/app.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/app.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../common';
+import common from '../common.js';
 
 export default {
     title: `${common.nginx}Config`,

--- a/src/nginxconfig/i18n/zh-tw/templates/callouts/index.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/callouts/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import droplet from './droplet';
-import contribute from './contribute';
+import droplet from './droplet.js';
+import contribute from './contribute.js';
 
 export default { droplet, contribute };

--- a/src/nginxconfig/i18n/zh-tw/templates/domain_sections/https.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/domain_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableEncryptedSslConnection: `${common.enable}加密的 ${common.ssl} 連線`,

--- a/src/nginxconfig/i18n/zh-tw/templates/domain_sections/index.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/domain_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,16 +24,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import php from './php';
-import presets from './presets';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import routing from './routing';
-import server from './server';
-import restrict from './restrict';
-import onion from './onion';
+import https from './https.js';
+import logging from './logging.js';
+import php from './php.js';
+import presets from './presets.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import routing from './routing.js';
+import server from './server.js';
+import restrict from './restrict.js';
+import onion from './onion.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/zh-tw/templates/domain_sections/logging.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/domain_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     byDomain: '在此網域',

--- a/src/nginxconfig/i18n/zh-tw/templates/domain_sections/php.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/domain_sections/php.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     phpIsDisabled: `${common.php} 已停用。`,

--- a/src/nginxconfig/i18n/zh-tw/templates/domain_sections/python.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/domain_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonIsDisabled: `${common.python} 已停用。`,

--- a/src/nginxconfig/i18n/zh-tw/templates/domain_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/domain_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     reverseProxyIsDisabled: `${common.reverseProxy} 已停用。`,

--- a/src/nginxconfig/i18n/zh-tw/templates/domain_sections/routing.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/domain_sections/routing.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     fallbackRouting: '後援路由',

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/docker.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/docker.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const docker = 'Docker';
 const dockerfile = 'Dockerfile';

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/https.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/https.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const mozilla = 'Mozilla';
 const ipv4 = 'IPv4';

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/index.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,15 +24,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import https from './https';
-import logging from './logging';
-import nginx from './nginx';
-import performance from './performance';
-import python from './python';
-import reverseProxy from './reverse_proxy';
-import security from './security';
-import tools from './tools';
-import docker from './docker';
+import https from './https.js';
+import logging from './logging.js';
+import nginx from './nginx.js';
+import performance from './performance.js';
+import python from './python.js';
+import reverseProxy from './reverse_proxy.js';
+import security from './security.js';
+import tools from './tools.js';
+import docker from './docker.js';
 
 export default {
     https,

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/logging.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/logging.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     enableFileNotFoundErrorLogging: `${common.enable}｢找不到檔案｣錯誤日誌：`,

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/nginx.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/nginx.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     nginxConfigDirectory: `${common.nginx} 設定目錄`,

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/performance.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/performance.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     disableHtmlCaching: 'Disable HTML caching', // TODO: translate

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/python.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/python.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     pythonServer: `${common.python} 服務`,

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/reverse_proxy.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/reverse_proxy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const legacyXForwarded = '傳統 X-Forwarded-* 標頭';
 

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/security.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/security.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     whenUsingWordPressUnsafeEvalIsOftenRequiredToAllowFunctionality: `使用 ${common.wordPress} 時，通常需在 CSP 中加入 <code class="slim">script-src 'self' 'unsafe-inline' 'unsafe-eval';</code>，以使管理面板正常運作。`,

--- a/src/nginxconfig/i18n/zh-tw/templates/global_sections/tools.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/global_sections/tools.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     modularizedStructure: '模組化結構',

--- a/src/nginxconfig/i18n/zh-tw/templates/index.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,12 +24,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import app from './app';
-import setup from './setup';
-import footer from './footer';
-import domainSections from './domain_sections';
-import globalSections from './global_sections';
-import setupSections from './setup_sections';
-import callouts from './callouts';
+import app from './app.js';
+import setup from './setup.js';
+import footer from './footer.js';
+import domainSections from './domain_sections/index.js';
+import globalSections from './global_sections/index.js';
+import setupSections from './setup_sections/index.js';
+import callouts from './callouts/index.js';
 
 export default { app, setup, footer, domainSections, globalSections, setupSections, callouts };

--- a/src/nginxconfig/i18n/zh-tw/templates/setup_sections/certbot.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/setup_sections/certbot.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 const certbot = 'Certbot';
 

--- a/src/nginxconfig/i18n/zh-tw/templates/setup_sections/download.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/setup_sections/download.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     downloadTheGeneratedConfig: '<b>下載</b>產生的設定：',

--- a/src/nginxconfig/i18n/zh-tw/templates/setup_sections/go_live.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/setup_sections/go_live.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     letsGoLive: '好戲上場！',

--- a/src/nginxconfig/i18n/zh-tw/templates/setup_sections/index.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/setup_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import certbot from './certbot';
-import download from './download';
-import goLive from './go_live';
-import ssl from './ssl';
+import certbot from './certbot.js';
+import download from './download.js';
+import goLive from './go_live.js';
+import ssl from './ssl.js';
 
 export default { certbot, download, goLive, ssl };

--- a/src/nginxconfig/i18n/zh-tw/templates/setup_sections/ssl.js
+++ b/src/nginxconfig/i18n/zh-tw/templates/setup_sections/ssl.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import common from '../../common';
+import common from '../../common.js';
 
 export default {
     generateDiffieHellmanKeysByRunningThisCommandOnYourServer:

--- a/src/nginxconfig/mount.js
+++ b/src/nginxconfig/mount.js
@@ -28,8 +28,8 @@ THE SOFTWARE.
 import './scss/style.scss';
 import 'vue-select/dist/vue-select.css';
 import { createApp } from 'vue';
-import './util/prism_bundle';
-import { getI18n } from './i18n/setup';
+import './util/prism_bundle.js';
+import { getI18n } from './i18n/setup.js';
 import App from './templates/app';
 
 // Load the i18n languages and run the app

--- a/src/nginxconfig/mount.js
+++ b/src/nginxconfig/mount.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -30,7 +30,7 @@ import 'vue-select/dist/vue-select.css';
 import { createApp } from 'vue';
 import './util/prism_bundle.js';
 import { getI18n } from './i18n/setup.js';
-import App from './templates/app';
+import App from './templates/app.vue';
 
 // Load the i18n languages and run the app
 getI18n().then((i18n) => {

--- a/src/nginxconfig/templates/app.vue
+++ b/src/nginxconfig/templates/app.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -168,28 +168,28 @@ THE SOFTWARE.
     import sha2_256 from 'simple-js-sha2-256';
     import escape from 'escape-html';
     import VueSelect from 'vue-select';
-    import Header from 'do-vue/src/templates/header';
+    import Header from 'do-vue/src/templates/header.vue';
     import diff from 'files-diff';
 
-    import isChanged from '../util/is_changed';
-    import importData from '../util/import_data';
-    import isObject from '../util/is_object';
-    import analytics from '../util/analytics';
-    import browserLanguage from '../util/browser_language';
-    import { defaultPack, availablePacks } from '../util/language_packs';
-    import { info, error } from '../util/log';
+    import isChanged from '../util/is_changed.js';
+    import importData from '../util/import_data.js';
+    import isObject from '../util/is_object.js';
+    import analytics from '../util/analytics.js';
+    import browserLanguage from '../util/browser_language.js';
+    import { defaultPack, availablePacks } from '../util/language_packs.js';
+    import { info, error } from '../util/log.js';
 
-    import { setLanguagePack } from '../i18n/setup';
-    import generators from '../generators';
+    import { setLanguagePack } from '../i18n/setup.js';
+    import generators from '../generators/index.js';
 
-    import Domain from './domain';
-    import Global from './global';
-    import DropletCallout from './callouts/droplet';
-    import ContributeCallout from './callouts/contribute';
-    import Setup from './setup';
-    import Footer from './footer';
+    import Domain from './domain.vue';
+    import Global from './global.vue';
+    import DropletCallout from './callouts/droplet.vue';
+    import ContributeCallout from './callouts/contribute.vue';
+    import Setup from './setup.vue';
+    import Footer from './footer.vue';
 
-    import NginxPrism from './prism/nginx';
+    import NginxPrism from './prism/nginx.vue';
 
     export default {
         name: 'App',
@@ -203,8 +203,8 @@ THE SOFTWARE.
             ContributeCallout,
             Setup,
             NginxPrism,
-            YamlPrism: defineAsyncComponent(() => import('./prism/yaml')),
-            DockerPrism: defineAsyncComponent(() => import('./prism/docker')),
+            YamlPrism: defineAsyncComponent(() => import('./prism/yaml.vue')),
+            DockerPrism: defineAsyncComponent(() => import('./prism/docker.vue')),
         },
         data() {
             return {

--- a/src/nginxconfig/templates/callouts/contribute.vue
+++ b/src/nginxconfig/templates/callouts/contribute.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -49,7 +49,7 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import analytics from '../../util/analytics';
+    import analytics from '../../util/analytics.js';
 
     export default {
         name: 'ContributeCallout',

--- a/src/nginxconfig/templates/callouts/droplet.vue
+++ b/src/nginxconfig/templates/callouts/droplet.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -38,8 +38,8 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import ExternalLink from 'do-vue/src/templates/external_link';
-    import analytics from '../../util/analytics';
+    import ExternalLink from 'do-vue/src/templates/external_link.vue';
+    import analytics from '../../util/analytics.js';
 
     export default {
         name: 'DropletCallout',

--- a/src/nginxconfig/templates/domain.vue
+++ b/src/nginxconfig/templates/domain.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -81,10 +81,10 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import analytics from '../util/analytics';
-    import isChanged from '../util/is_changed';
-    import Presets from './domain_sections/presets';
-    import Sections from './domain_sections';
+    import analytics from '../util/analytics.js';
+    import isChanged from '../util/is_changed.js';
+    import Presets from './domain_sections/presets.vue';
+    import Sections from './domain_sections/index.js';
 
     const delegated = {
         hasUserInteraction: false,

--- a/src/nginxconfig/templates/domain_sections/https.vue
+++ b/src/nginxconfig/templates/domain_sections/https.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -306,12 +306,12 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import ExternalLink from 'do-vue/src/templates/external_link';
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
-    import { serverDomainDefault } from '../../util/defaults';
-    import PrettyCheck from '../inputs/checkbox';
-    import PrettyRadio from '../inputs/radio';
+    import ExternalLink from 'do-vue/src/templates/external_link.vue';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
+    import { serverDomainDefault } from '../../util/defaults.js';
+    import PrettyCheck from '../inputs/checkbox.vue';
+    import PrettyRadio from '../inputs/radio.vue';
 
     const defaults = {
         https: {

--- a/src/nginxconfig/templates/domain_sections/index.js
+++ b/src/nginxconfig/templates/domain_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,14 +24,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import Server from './server';
-import HTTPS from './https';
-import PHP from './php';
-import Python from './python';
-import ReverseProxy from './reverse_proxy';
-import Routing from './routing';
-import Logging from './logging';
-import Restrict from './restrict';
-import Onion from './onion';
+import Server from './server.vue';
+import HTTPS from './https.vue';
+import PHP from './php.vue';
+import Python from './python.vue';
+import ReverseProxy from './reverse_proxy.vue';
+import Routing from './routing.vue';
+import Logging from './logging.vue';
+import Restrict from './restrict.vue';
+import Onion from './onion.vue';
 
 export default [Server, HTTPS, PHP, Python, ReverseProxy, Routing, Logging, Restrict, Onion];

--- a/src/nginxconfig/templates/domain_sections/logging.vue
+++ b/src/nginxconfig/templates/domain_sections/logging.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -198,8 +198,8 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
     import {
         accessLogPathDefault,
         accessLogParamsDefault,
@@ -208,9 +208,9 @@ THE SOFTWARE.
         errorLogLevelDefault,
         errorLogLevelOptions,
         errorLogLevelDisabled,
-    } from '../../util/logging';
-    import PrettyCheck from '../inputs/checkbox';
-    import PrettyRadio from '../inputs/radio';
+    } from '../../util/logging.js';
+    import PrettyCheck from '../inputs/checkbox.vue';
+    import PrettyRadio from '../inputs/radio.vue';
 
     const defaults = {
         accessLogEnabled: {

--- a/src/nginxconfig/templates/domain_sections/onion.vue
+++ b/src/nginxconfig/templates/domain_sections/onion.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -97,9 +97,9 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import ExternalLink from 'do-vue/src/templates/external_link';
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
+    import ExternalLink from 'do-vue/src/templates/external_link.vue';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
 
     const defaults = {
         onionLocation: {

--- a/src/nginxconfig/templates/domain_sections/php.vue
+++ b/src/nginxconfig/templates/domain_sections/php.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -247,9 +247,9 @@ THE SOFTWARE.
 
 <script>
     import VueSelect from 'vue-select';
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
-    import PrettyCheck from '../inputs/checkbox';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
+    import PrettyCheck from '../inputs/checkbox.vue';
 
     // Value -> i18n key
     const serverOptions = {

--- a/src/nginxconfig/templates/domain_sections/presets.vue
+++ b/src/nginxconfig/templates/domain_sections/presets.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -64,9 +64,9 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
-    import analytics from '../../util/analytics';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
+    import analytics from '../../util/analytics.js';
 
     const defaults = {
         frontend: {

--- a/src/nginxconfig/templates/domain_sections/python.vue
+++ b/src/nginxconfig/templates/domain_sections/python.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -109,9 +109,9 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
-    import PrettyCheck from '../inputs/checkbox';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
+    import PrettyCheck from '../inputs/checkbox.vue';
 
     const defaults = {
         python: {

--- a/src/nginxconfig/templates/domain_sections/restrict.vue
+++ b/src/nginxconfig/templates/domain_sections/restrict.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -267,9 +267,9 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
-    import PrettyCheck from '../inputs/checkbox';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
+    import PrettyCheck from '../inputs/checkbox.vue';
 
     const defaults = {
         getMethod: {

--- a/src/nginxconfig/templates/domain_sections/reverse_proxy.vue
+++ b/src/nginxconfig/templates/domain_sections/reverse_proxy.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -151,9 +151,9 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
-    import PrettyCheck from '../inputs/checkbox';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
+    import PrettyCheck from '../inputs/checkbox.vue';
 
     const defaults = {
         reverseProxy: {

--- a/src/nginxconfig/templates/domain_sections/routing.vue
+++ b/src/nginxconfig/templates/domain_sections/routing.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -165,10 +165,10 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
-    import PrettyCheck from '../inputs/checkbox';
-    import PrettyRadio from '../inputs/radio';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
+    import PrettyCheck from '../inputs/checkbox.vue';
+    import PrettyRadio from '../inputs/radio.vue';
 
     const defaults = {
         root: {

--- a/src/nginxconfig/templates/domain_sections/server.vue
+++ b/src/nginxconfig/templates/domain_sections/server.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -198,10 +198,10 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
-    import { serverDomainDefault } from '../../util/defaults';
-    import PrettyCheck from '../inputs/checkbox';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
+    import { serverDomainDefault } from '../../util/defaults.js';
+    import PrettyCheck from '../inputs/checkbox.vue';
 
     const defaults = {
         domain: {

--- a/src/nginxconfig/templates/footer.vue
+++ b/src/nginxconfig/templates/footer.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -69,7 +69,7 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import ExternalLink from 'do-vue/src/templates/external_link';
+    import ExternalLink from 'do-vue/src/templates/external_link.vue';
 
     export default {
         name: 'Footer',

--- a/src/nginxconfig/templates/global.vue
+++ b/src/nginxconfig/templates/global.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -75,9 +75,9 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import analytics from '../util/analytics';
-    import isChanged from '../util/is_changed';
-    import Sections from './global_sections';
+    import analytics from '../util/analytics.js';
+    import isChanged from '../util/is_changed.js';
+    import Sections from './global_sections/index.js';
 
     const delegated = Sections.reduce((prev, tab) => {
         prev[tab.key] = tab.delegated;

--- a/src/nginxconfig/templates/global_sections/docker.vue
+++ b/src/nginxconfig/templates/global_sections/docker.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -97,10 +97,10 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
-    import analytics from '../../util/analytics';
-    import PrettyCheck from '../inputs/checkbox';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
+    import analytics from '../../util/analytics.js';
+    import PrettyCheck from '../inputs/checkbox.vue';
 
     const defaults = {
         dockerfile: {

--- a/src/nginxconfig/templates/global_sections/https.vue
+++ b/src/nginxconfig/templates/global_sections/https.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -327,10 +327,10 @@ THE SOFTWARE.
 
 <script>
     import clone from 'clone';
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
-    import PrettyCheck from '../inputs/checkbox';
-    import PrettyRadio from '../inputs/radio';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
+    import PrettyCheck from '../inputs/checkbox.vue';
+    import PrettyRadio from '../inputs/radio.vue';
 
     const ipType = {
         default: 'ipv4',

--- a/src/nginxconfig/templates/global_sections/index.js
+++ b/src/nginxconfig/templates/global_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,14 +24,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import HTTPS from './https';
-import Security from './security';
-import Python from './python';
-import ReverseProxy from './reverse_proxy';
-import Performance from './performance';
-import Logging from './logging';
-import NGINX from './nginx';
-import Docker from './docker';
-import Tools from './tools';
+import HTTPS from './https.vue';
+import Security from './security.vue';
+import Python from './python.vue';
+import ReverseProxy from './reverse_proxy.vue';
+import Performance from './performance.vue';
+import Logging from './logging.vue';
+import NGINX from './nginx.vue';
+import Docker from './docker.vue';
+import Tools from './tools.vue';
 
 export default [HTTPS, Security, Python, ReverseProxy, Performance, Logging, NGINX, Docker, Tools];

--- a/src/nginxconfig/templates/global_sections/logging.vue
+++ b/src/nginxconfig/templates/global_sections/logging.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -245,15 +245,15 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
     import {
         errorLogPathDefault,
         errorLogLevelDefault,
         errorLogLevelOptions,
-    } from '../../util/logging';
-    import PrettyCheck from '../inputs/checkbox';
-    import PrettyRadio from '../inputs/radio';
+    } from '../../util/logging.js';
+    import PrettyCheck from '../inputs/checkbox.vue';
+    import PrettyRadio from '../inputs/radio.vue';
 
     const defaults = {
         errorLogEnabled: {

--- a/src/nginxconfig/templates/global_sections/nginx.vue
+++ b/src/nginxconfig/templates/global_sections/nginx.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -166,8 +166,8 @@ THE SOFTWARE.
 
 <script>
     import VueSelect from 'vue-select';
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
 
     const defaults = {
         nginxConfigDirectory: {

--- a/src/nginxconfig/templates/global_sections/performance.vue
+++ b/src/nginxconfig/templates/global_sections/performance.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -213,10 +213,10 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import ExternalLink from 'do-vue/src/templates/external_link';
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
-    import PrettyCheck from '../inputs/checkbox';
+    import ExternalLink from 'do-vue/src/templates/external_link.vue';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
+    import PrettyCheck from '../inputs/checkbox.vue';
 
     const defaults = {
         disableHtmlCaching: {

--- a/src/nginxconfig/templates/global_sections/python.vue
+++ b/src/nginxconfig/templates/global_sections/python.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -72,8 +72,8 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
 
     const defaults = {
         pythonServer: {

--- a/src/nginxconfig/templates/global_sections/reverse_proxy.vue
+++ b/src/nginxconfig/templates/global_sections/reverse_proxy.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -172,9 +172,9 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
-    import PrettyRadio from '../inputs/radio';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
+    import PrettyRadio from '../inputs/radio.vue';
 
     const defaults = {
         proxyConnectTimeout: {

--- a/src/nginxconfig/templates/global_sections/security.vue
+++ b/src/nginxconfig/templates/global_sections/security.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -181,9 +181,9 @@ THE SOFTWARE.
 
 <script>
     import VueSelect from 'vue-select';
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
-    import PrettyCheck from '../inputs/checkbox';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
+    import PrettyCheck from '../inputs/checkbox.vue';
 
     const defaults = {
         referrerPolicy: {

--- a/src/nginxconfig/templates/global_sections/tools.vue
+++ b/src/nginxconfig/templates/global_sections/tools.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -196,12 +196,12 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import Modal from 'do-vue/src/templates/modal';
-    import delegatedFromDefaults from '../../util/delegated_from_defaults';
-    import computedFromDefaults from '../../util/computed_from_defaults';
-    import shareQuery from '../../util/share_query';
-    import analytics from '../../util/analytics';
-    import PrettyCheck from '../inputs/checkbox';
+    import Modal from 'do-vue/src/templates/modal.vue';
+    import delegatedFromDefaults from '../../util/delegated_from_defaults.js';
+    import computedFromDefaults from '../../util/computed_from_defaults.js';
+    import shareQuery from '../../util/share_query.js';
+    import analytics from '../../util/analytics.js';
+    import PrettyCheck from '../inputs/checkbox.vue';
 
     const defaults = {
         modularizedStructure: {

--- a/src/nginxconfig/templates/inputs/checkbox.vue
+++ b/src/nginxconfig/templates/inputs/checkbox.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -47,5 +47,5 @@ THE SOFTWARE.
 </template>
 
 <script setup>
-    import PrettyCheck from 'do-vue/src/templates/pretty-checkbox-vue/pretty_check';
+    import PrettyCheck from 'do-vue/src/templates/pretty-checkbox-vue/pretty_check.vue';
 </script>

--- a/src/nginxconfig/templates/inputs/radio.vue
+++ b/src/nginxconfig/templates/inputs/radio.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -47,5 +47,5 @@ THE SOFTWARE.
 </template>
 
 <script setup>
-    import PrettyRadio from 'do-vue/src/templates/pretty-checkbox-vue/pretty_radio';
+    import PrettyRadio from 'do-vue/src/templates/pretty-checkbox-vue/pretty_radio.vue';
 </script>

--- a/src/nginxconfig/templates/prism/bash.vue
+++ b/src/nginxconfig/templates/prism/bash.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -31,7 +31,7 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import { info } from '../../util/log';
+    import { info } from '../../util/log.js';
 
     export default {
         name: 'BashPrism',

--- a/src/nginxconfig/templates/prism/docker.vue
+++ b/src/nginxconfig/templates/prism/docker.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -35,8 +35,8 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import 'prismjs/components/prism-docker';
-    import { info } from '../../util/log';
+    import 'prismjs/components/prism-docker.js';
+    import { info } from '../../util/log.js';
 
     export default {
         name: 'DockerPrism',

--- a/src/nginxconfig/templates/prism/nginx.vue
+++ b/src/nginxconfig/templates/prism/nginx.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -35,7 +35,7 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import { info } from '../../util/log';
+    import { info } from '../../util/log.js';
 
     export default {
         name: 'NginxPrism',

--- a/src/nginxconfig/templates/prism/yaml.vue
+++ b/src/nginxconfig/templates/prism/yaml.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -35,8 +35,8 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import 'prismjs/components/prism-yaml';
-    import { info } from '../../util/log';
+    import 'prismjs/components/prism-yaml.js';
+    import { info } from '../../util/log.js';
 
     export default {
         name: 'YamlPrism',

--- a/src/nginxconfig/templates/setup.vue
+++ b/src/nginxconfig/templates/setup.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -87,8 +87,8 @@ THE SOFTWARE.
 <script>
     import Tar from 'memory-tar-create';
     import ClipboardJS from 'clipboard';
-    import analytics from '../util/analytics';
-    import Sections from './setup_sections';
+    import analytics from '../util/analytics.js';
+    import Sections from './setup_sections/index.js';
 
     export default {
         name: 'Setup',

--- a/src/nginxconfig/templates/setup_sections/certbot.vue
+++ b/src/nginxconfig/templates/setup_sections/certbot.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -138,8 +138,8 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import BashPrism from '../prism/bash';
-    import analytics from '../../util/analytics';
+    import BashPrism from '../prism/bash.vue';
+    import analytics from '../../util/analytics.js';
 
     export default {
         name: 'SetupCertbot',

--- a/src/nginxconfig/templates/setup_sections/download.vue
+++ b/src/nginxconfig/templates/setup_sections/download.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -123,8 +123,8 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import BashPrism from '../prism/bash';
-    import analytics from '../../util/analytics';
+    import BashPrism from '../prism/bash.vue';
+    import analytics from '../../util/analytics.js';
 
     export default {
         name: 'SetupDownload',

--- a/src/nginxconfig/templates/setup_sections/go_live.vue
+++ b/src/nginxconfig/templates/setup_sections/go_live.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -42,8 +42,8 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import BashPrism from '../prism/bash';
-    import analytics from '../../util/analytics';
+    import BashPrism from '../prism/bash.vue';
+    import analytics from '../../util/analytics.js';
 
     export default {
         name: 'SetupGoLive',

--- a/src/nginxconfig/templates/setup_sections/index.js
+++ b/src/nginxconfig/templates/setup_sections/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import Download from './download';
-import SSL from './ssl';
-import Certbot from './certbot';
-import GoLive from './go_live';
+import Download from './download.vue';
+import SSL from './ssl.vue';
+import Certbot from './certbot.vue';
+import GoLive from './go_live.vue';
 
 export default [Download, SSL, Certbot, GoLive];

--- a/src/nginxconfig/templates/setup_sections/ssl.vue
+++ b/src/nginxconfig/templates/setup_sections/ssl.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -91,8 +91,8 @@ THE SOFTWARE.
 </template>
 
 <script>
-    import BashPrism from '../prism/bash';
-    import analytics from '../../util/analytics';
+    import BashPrism from '../prism/bash.vue';
+    import analytics from '../../util/analytics.js';
 
     export default {
         name: 'SetupSSL',

--- a/src/nginxconfig/util/analytics.js
+++ b/src/nginxconfig/util/analytics.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/util/analytics.js
+++ b/src/nginxconfig/util/analytics.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { info } from './log';
+import { info } from './log.js';
 
 export default ({ category, action, label, value, nonInteraction }) => {
     info('Analytics event:', { category, action, label, value, nonInteraction });

--- a/src/nginxconfig/util/angular_backwards_compatibility.js
+++ b/src/nginxconfig/util/angular_backwards_compatibility.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/util/angular_backwards_compatibility.js
+++ b/src/nginxconfig/util/angular_backwards_compatibility.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import isObject from './is_object';
+import isObject from './is_object.js';
 
 const oldBool = (val) => (val.toString().trim() === '' ? true : val);
 

--- a/src/nginxconfig/util/browser_language.js
+++ b/src/nginxconfig/util/browser_language.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/util/browser_language.js
+++ b/src/nginxconfig/util/browser_language.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { fromSep } from './language_packs';
+import { fromSep } from './language_packs.js';
 
 export default (availablePacks) => {
     if (typeof window === 'object' && typeof window.navigator === 'object') {

--- a/src/nginxconfig/util/computed_from_defaults.js
+++ b/src/nginxconfig/util/computed_from_defaults.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import isChanged from './is_changed';
+import isChanged from './is_changed.js';
 
 export default (defaults, cat, isInteraction = true) => {
     return Object.keys(defaults).reduce((prev, key) => {

--- a/src/nginxconfig/util/computed_from_defaults.js
+++ b/src/nginxconfig/util/computed_from_defaults.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/util/import_data.js
+++ b/src/nginxconfig/util/import_data.js
@@ -27,9 +27,9 @@ THE SOFTWARE.
 import qs from 'qs';
 import clone from 'clone';
 import Domain from '../templates/domain';
-import isObject from './is_object';
-import angularBackwardsCompatibility from './angular_backwards_compatibility';
-import vueBackwardsCompatibility from './vue_backwards_compatibility';
+import isObject from './is_object.js';
+import angularBackwardsCompatibility from './angular_backwards_compatibility.js';
+import vueBackwardsCompatibility from './vue_backwards_compatibility.js';
 
 const applyCategories = (categories, target) => {
     // Work through each potential category

--- a/src/nginxconfig/util/import_data.js
+++ b/src/nginxconfig/util/import_data.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/util/import_data.js
+++ b/src/nginxconfig/util/import_data.js
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 import qs from 'qs';
 import clone from 'clone';
-import Domain from '../templates/domain';
+import Domain from '../templates/domain.vue';
 import isObject from './is_object.js';
 import angularBackwardsCompatibility from './angular_backwards_compatibility.js';
 import vueBackwardsCompatibility from './vue_backwards_compatibility.js';

--- a/src/nginxconfig/util/language_packs.js
+++ b/src/nginxconfig/util/language_packs.js
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 export const defaultPack = 'en';
 
-export { default as defaultPackData } from '../i18n/en';
+export { default as defaultPackData } from '../i18n/en/index.js';
 
 export const toSep = (pack, sep) =>
     pack

--- a/src/nginxconfig/util/logging.js
+++ b/src/nginxconfig/util/logging.js
@@ -24,12 +24,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-export const accessLogPathDefault = '/var/log/nginx/access.log.js';
-export const accessLogParamsDefault = 'buffer=512k flush=1m.js';
+export const accessLogPathDefault = '/var/log/nginx/access.log';
+export const accessLogParamsDefault = 'buffer=512k flush=1m';
 
-export const errorLogPathDefault = '/var/log/nginx/error.log.js';
-export const errorLogPathDisabled = '/dev/null.js';
-export const errorLogLevelDefault = 'warn.js';
+export const errorLogPathDefault = '/var/log/nginx/error.log';
+export const errorLogPathDisabled = '/dev/null';
+export const errorLogLevelDefault = 'warn';
 export const errorLogLevelOptions = Object.freeze([
     'debug',
     'info',

--- a/src/nginxconfig/util/logging.js
+++ b/src/nginxconfig/util/logging.js
@@ -24,12 +24,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-export const accessLogPathDefault = '/var/log/nginx/access.log';
-export const accessLogParamsDefault = 'buffer=512k flush=1m';
+export const accessLogPathDefault = '/var/log/nginx/access.log.js';
+export const accessLogParamsDefault = 'buffer=512k flush=1m.js';
 
-export const errorLogPathDefault = '/var/log/nginx/error.log';
-export const errorLogPathDisabled = '/dev/null';
-export const errorLogLevelDefault = 'warn';
+export const errorLogPathDefault = '/var/log/nginx/error.log.js';
+export const errorLogPathDisabled = '/dev/null.js';
+export const errorLogLevelDefault = 'warn.js';
 export const errorLogLevelOptions = Object.freeze([
     'debug',
     'info',

--- a/src/nginxconfig/util/prism_bundle.js
+++ b/src/nginxconfig/util/prism_bundle.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -26,13 +26,13 @@ THE SOFTWARE.
 
 import Clipboard from 'clipboard';
 import Prism from 'prismjs';
-import 'prismjs/components/prism-nginx';
-import 'prismjs/components/prism-bash';
-import 'prismjs/plugins/keep-markup/prism-keep-markup';
-import 'prismjs/plugins/toolbar/prism-toolbar';
+import 'prismjs/components/prism-nginx.js';
+import 'prismjs/components/prism-bash.js';
+import 'prismjs/plugins/keep-markup/prism-keep-markup.js';
+import 'prismjs/plugins/toolbar/prism-toolbar.js';
 import 'prismjs/plugins/toolbar/prism-toolbar.css';
 
-import { warn } from './log';
+import { warn } from './log.js';
 
 // Custom copy to clipboard (based on the Prism one)
 const copyToClipboard = () => {

--- a/src/nginxconfig/util/share_query.js
+++ b/src/nginxconfig/util/share_query.js
@@ -25,7 +25,7 @@ THE SOFTWARE.
 */
 
 import qs from 'qs';
-import exportData from './export_data';
+import exportData from './export_data.js';
 
 export default (domains, global) => {
     const data = exportData(domains, global);

--- a/src/nginxconfig/util/share_query.js
+++ b/src/nginxconfig/util/share_query.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/util/vue_backwards_compatibility.js
+++ b/src/nginxconfig/util/vue_backwards_compatibility.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/src/nginxconfig/util/vue_backwards_compatibility.js
+++ b/src/nginxconfig/util/vue_backwards_compatibility.js
@@ -24,16 +24,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import isObject from './is_object';
-import deepMerge from './deep_merge';
+import isObject from './is_object.js';
+import deepMerge from './deep_merge.js';
 import {
     accessLogPathDefault,
     accessLogParamsDefault,
     errorLogPathDefault,
     errorLogPathDisabled,
     errorLogLevelDefault,
-} from './logging';
-import { serverDomainDefault } from './defaults';
+} from './logging.js';
+import { serverDomainDefault } from './defaults.js';
 
 // Migrate old logging settings to new ones
 const migrateLogging = (data) => {

--- a/test/testBrowserLanguage.js
+++ b/test/testBrowserLanguage.js
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import browserLanguage from '../src/nginxconfig/util/browser_language';
+import browserLanguage from '../src/nginxconfig/util/browser_language.js';
 
 class MockLocales {
     static languages = [];
@@ -83,23 +83,26 @@ class MockLocales {
     }
 }
 
-Object.defineProperty(window.navigator, 'languages', { get: () => {
-    return MockLocales.languages || [];
-}});
+Object.defineProperty(window.navigator, 'languages', {
+    get: () => {
+        return MockLocales.languages || [];
+    },
+});
 
-Object.defineProperty(window.navigator, 'language', { get: () => {
-    return MockLocales.language || null;
-}});
-
+Object.defineProperty(window.navigator, 'language', {
+    get: () => {
+        return MockLocales.language || null;
+    },
+});
 
 describe('browserLanguage', () => {
     test('Selects the first available exact match for language/region', () => {
         MockLocales.setDateTimeLocale(undefined);
 
-        MockLocales.setNavigatorLanguages(['zh-CN', 'zh','en-US','en']);
+        MockLocales.setNavigatorLanguages(['zh-CN', 'zh', 'en-US', 'en']);
         expect(browserLanguage(['en', 'zhCN', 'zhTW'])).toEqual('zhCN');
 
-        MockLocales.setNavigatorLanguages(['zh-TW','zh','en-US','en']);
+        MockLocales.setNavigatorLanguages(['zh-TW', 'zh', 'en-US', 'en']);
         expect(browserLanguage(['en', 'zhCN', 'zhTW'])).toEqual('zhTW');
 
         MockLocales.setNavigatorLanguages(['zh', 'en-US', 'en']);
@@ -108,7 +111,7 @@ describe('browserLanguage', () => {
         MockLocales.restoreDateTimeLocale();
     });
 
-    test('Selects the first available language match based on language/region',() => {
+    test('Selects the first available language match based on language/region', () => {
         MockLocales.setDateTimeLocale(undefined);
 
         MockLocales.setNavigatorLanguages(['ja-JP', 'ja', 'en-US']);
@@ -117,7 +120,7 @@ describe('browserLanguage', () => {
         MockLocales.restoreDateTimeLocale();
     });
 
-    test('Selects the first available language match based on language alone',() => {
+    test('Selects the first available language match based on language alone', () => {
         MockLocales.setDateTimeLocale(undefined);
 
         MockLocales.setNavigatorLanguages(['ja-JP', 'ja', 'zh']);
@@ -126,17 +129,17 @@ describe('browserLanguage', () => {
         MockLocales.restoreDateTimeLocale();
     });
 
-    test('Returns false when there is no available match',() => {
+    test('Returns false when there is no available match', () => {
         MockLocales.setDateTimeLocale(undefined);
 
-        MockLocales.setNavigatorLanguages(['ja-JP','ja']);
+        MockLocales.setNavigatorLanguages(['ja-JP', 'ja']);
         expect(browserLanguage(['en', 'zhCN', 'zhTW'])).toBeFalsy();
 
         MockLocales.restoreDateTimeLocale();
     });
 
     describe('Different sources for user locale', () => {
-        test('language, languages and Intl locale are `undefined`',() => {
+        test('language, languages and Intl locale are `undefined`', () => {
             MockLocales.setNavigatorLanguages(undefined);
             MockLocales.setNavigatorLanguage(undefined);
             MockLocales.setDateTimeLocale(undefined);
@@ -144,7 +147,7 @@ describe('browserLanguage', () => {
             MockLocales.restoreDateTimeLocale();
         });
 
-        test('language is `en`, languages and Intl locale are `undefined`',() => {
+        test('language is `en`, languages and Intl locale are `undefined`', () => {
             MockLocales.setNavigatorLanguage('en');
             MockLocales.setNavigatorLanguages(undefined);
             MockLocales.setDateTimeLocale(undefined);
@@ -152,15 +155,15 @@ describe('browserLanguage', () => {
             MockLocales.restoreDateTimeLocale();
         });
 
-        test('language and Intl locale are `undefined`, languages is `en-US, en`',() => {
+        test('language and Intl locale are `undefined`, languages is `en-US, en`', () => {
             MockLocales.setNavigatorLanguage(undefined);
-            MockLocales.setNavigatorLanguages(['en-US','en']);
+            MockLocales.setNavigatorLanguages(['en-US', 'en']);
             MockLocales.setDateTimeLocale(undefined);
             expect(browserLanguage(['en', 'zhCN', 'zhTW'])).toEqual('en');
             MockLocales.restoreDateTimeLocale();
         });
 
-        test('navigator is `undefined` and Intl locale is `en-US`',() => {
+        test('navigator is `undefined` and Intl locale is `en-US`', () => {
             MockLocales.setNavigator(undefined);
             MockLocales.setDateTimeLocale('en-US');
             expect(browserLanguage(['en', 'zhCN', 'zhTW'])).toEqual('en');

--- a/test/testBrowserLanguage.js
+++ b/test/testBrowserLanguage.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -42,12 +42,22 @@ export default {
         node: false, // Disable Node.js polyfills (Buffer etc.) -- This will be default in Webpack 5
         plugins: [
             // Fix dynamic imports from CDN (inject as first entry point before any imports can happen)
-            { apply: compiler => {
-                compiler.options.entry.app.import.unshift(
-                    fileURLToPath(new URL('src/nginxconfig/build/webpack-dynamic-import.js', import.meta.url)),
-                );
-            } },
-            new WebpackRequireFrom({ methodName: '__webpackDynamicImportURL', suppressErrors: true }),
+            {
+                apply: (compiler) => {
+                    compiler.options.entry.app.import.unshift(
+                        fileURLToPath(
+                            new URL(
+                                'src/nginxconfig/build/webpack-dynamic-import.js',
+                                import.meta.url,
+                            ),
+                        ),
+                    );
+                },
+            },
+            new WebpackRequireFrom({
+                methodName: '__webpackDynamicImportURL',
+                suppressErrors: true,
+            }),
             // Pass the env in for logging
             new webpack.EnvironmentPlugin({ NODE_ENV: 'development' }),
             // Analyze the bundle
@@ -55,10 +65,11 @@ export default {
             new DuplicatePackageCheckerPlugin(),
         ],
     },
-    chainWebpack: config => {
+    chainWebpack: (config) => {
         // Inject resolve-url-loader into the SCSS loader rules (to allow relative fonts in do-bulma to work)
         for (const rule of ['vue-modules', 'vue', 'normal-modules', 'normal']) {
-            config.module.rule('scss')
+            config.module
+                .rule('scss')
                 .oneOf(rule)
                 .use('resolve-url-loader')
                 .loader('resolve-url-loader')
@@ -66,11 +77,11 @@ export default {
                 .end()
                 .use('sass-loader')
                 .loader('sass-loader')
-                .tap(options => ({ ...options, sourceMap: true }));
+                .tap((options) => ({ ...options, sourceMap: true }));
         }
 
         // Use a custom HTML template
-        config.plugin('html').tap(options => {
+        config.plugin('html').tap((options) => {
             options[0].template = fileURLToPath(new URL('build/index.html', import.meta.url));
             return options;
         });

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 DigitalOcean
+Copyright 2022 DigitalOcean
 
 This code is licensed under the MIT License.
 You may obtain a copy of the License at
@@ -42,22 +42,12 @@ export default {
         node: false, // Disable Node.js polyfills (Buffer etc.) -- This will be default in Webpack 5
         plugins: [
             // Fix dynamic imports from CDN (inject as first entry point before any imports can happen)
-            {
-                apply: (compiler) => {
-                    compiler.options.entry.app.import.unshift(
-                        fileURLToPath(
-                            new URL(
-                                'src/nginxconfig/build/webpack-dynamic-import.js',
-                                import.meta.url,
-                            ),
-                        ),
-                    );
-                },
-            },
-            new WebpackRequireFrom({
-                methodName: '__webpackDynamicImportURL',
-                suppressErrors: true,
-            }),
+            { apply: compiler => {
+                compiler.options.entry.app.import.unshift(
+                    fileURLToPath(new URL('src/nginxconfig/build/webpack-dynamic-import.js', import.meta.url)),
+                );
+            } },
+            new WebpackRequireFrom({ methodName: '__webpackDynamicImportURL', suppressErrors: true }),
             // Pass the env in for logging
             new webpack.EnvironmentPlugin({ NODE_ENV: 'development' }),
             // Analyze the bundle
@@ -65,11 +55,10 @@ export default {
             new DuplicatePackageCheckerPlugin(),
         ],
     },
-    chainWebpack: (config) => {
+    chainWebpack: config => {
         // Inject resolve-url-loader into the SCSS loader rules (to allow relative fonts in do-bulma to work)
         for (const rule of ['vue-modules', 'vue', 'normal-modules', 'normal']) {
-            config.module
-                .rule('scss')
+            config.module.rule('scss')
                 .oneOf(rule)
                 .use('resolve-url-loader')
                 .loader('resolve-url-loader')
@@ -77,11 +66,11 @@ export default {
                 .end()
                 .use('sass-loader')
                 .loader('sass-loader')
-                .tap((options) => ({ ...options, sourceMap: true }));
+                .tap(options => ({ ...options, sourceMap: true }));
         }
 
         // Use a custom HTML template
-        config.plugin('html').tap((options) => {
+        config.plugin('html').tap(options => {
             options[0].template = fileURLToPath(new URL('build/index.html', import.meta.url));
             return options;
         });


### PR DESCRIPTION
### **Type of Change:**  
Tool Source: JS

### **What issue does this relate to?**  
This PR resolves #454.

### **What should this PR do?**  
- Removed all `esm + extensionless` usages from the project.  
- Updated ESLint configuration to enforce file extensions in import statements.  
- Ensured all imports in the project now include proper file extensions.  
- Updated the project’s `package.json` to set `"type": "module"`.  
- Updated the year in the copyright header for all modified files.

### **What are the acceptance criteria?**  
- No remaining extensionless imports.  
- ESLint configuration correctly enforces file extensions.  
- Copyright headers are updated.

---

**Feedback:**  
Please review and let me know if any further adjustments are required. Thank you!

